### PR TITLE
[feat] 모듈 목록 조회 팝업창 컴포넌트 구현 및 그래프 파싱 로직 수정

### DIFF
--- a/src/renderer/components/topology/TopologyPage.tsx
+++ b/src/renderer/components/topology/TopologyPage.tsx
@@ -40,9 +40,7 @@ export const TopologyPage = () => {
   const dispatch = useAppDispatch();
 
   React.useEffect(() => {
-    (async () => {
-      dispatch(fetchGraphData(workspaceUid));
-    })();
+    dispatch(fetchGraphData(workspaceUid));
   }, [dispatch, workspaceUid]);
 
   if (!localStorage.getItem('schemaJson')) {

--- a/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
+++ b/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceName } from '@renderer/hooks/useWorkspaceName';
 import {
   FitScreenButton,
   SaveButton,
+  SelectModuleButton,
   ZoomInButton,
   ZoomOutButton,
 } from './button';
@@ -23,7 +24,7 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
   const { handlers } = props;
   const [openModuleListModal, setOpenModuleListModal] = React.useState(false);
 
-  //const handleModuleListModalOpen = () => setOpenModuleListModal(true);
+  const handleModuleListModalOpen = () => setOpenModuleListModal(true);
   const handleModuleListModalClose = () => setOpenModuleListModal(false);
 
   const fileObjects = useAppSelector(selectCodeFileObjects);
@@ -61,7 +62,7 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
             console.log('[INFO] File export result : ', result);
           }}
         />
-        {/* <SelectModuleButton onClick={handleModuleListModalOpen} /> */}
+        <SelectModuleButton onClick={handleModuleListModalOpen} />
         <ModuleListModal
           isOpen={openModuleListModal}
           onClose={handleModuleListModalClose}

--- a/src/renderer/components/topology/toolbar/button/FitScreenButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/FitScreenButton.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import Tooltip from '@mui/material/Tooltip';
+import { styled, Tooltip } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
-import FitScreenIcon from '@mui/icons-material/FitScreen';
+import ZoomOutMapOutlinedIcon from '@mui/icons-material/ZoomOutMapOutlined';
+
+const FitScreenButtonIcon = styled(ZoomOutMapOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
 
 const FitScreenButton = (props: FitScreenButtonProps) => {
   const {
     label = '화면에 맞춤',
-    icon = <FitScreenIcon />,
+    icon = <FitScreenButtonIcon fontSize="small" />,
     onClick,
     className,
     ...rest

--- a/src/renderer/components/topology/toolbar/button/SaveButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/SaveButton.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import Tooltip from '@mui/material/Tooltip';
+import { styled, Tooltip } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
-import SaveIcon from '@mui/icons-material/Save';
+import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
+
+const SaveButtonIcon = styled(SaveOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
 
 const SaveButton = (props: SaveButtonProps) => {
   const {
     label = '저장',
-    icon = <SaveIcon />,
+    icon = <SaveButtonIcon fontSize="small" />,
     onClick,
     className,
     ...rest

--- a/src/renderer/components/topology/toolbar/button/SelectModuleButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/SelectModuleButton.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import Tooltip from '@mui/material/Tooltip';
+import { styled, Tooltip } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
+
+const SelectModuleButtonIcon = styled(AccountTreeOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
 
 const SelectModuleButton = (props: SelectModuleButtonProps) => {
   const {
     label = '모듈',
-    icon = <AccountTreeIcon />,
+    icon = <SelectModuleButtonIcon fontSize="small" />,
     onClick,
     className,
     ...rest

--- a/src/renderer/components/topology/toolbar/button/ZoomInButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/ZoomInButton.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import Tooltip from '@mui/material/Tooltip';
+import { styled, Tooltip } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
-import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomInOutlinedIcon from '@mui/icons-material/ZoomInOutlined';
+
+const ZoomInButtonIcon = styled(ZoomInOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
 
 const ZoomInButton = (props: ZoomInButtonProps) => {
   const {
     label = '확대',
-    icon = <ZoomInIcon />,
+    icon = <ZoomInButtonIcon fontSize="small" />,
     onClick,
     className,
     ...rest

--- a/src/renderer/components/topology/toolbar/button/ZoomOutButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/ZoomOutButton.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
-import Tooltip from '@mui/material/Tooltip';
+import { styled, Tooltip } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
-import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import ZoomOutOutlinedIcon from '@mui/icons-material/ZoomOutOutlined';
+
+const ZoomOutButtonIcon = styled(ZoomOutOutlinedIcon)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
 
 const ZoomOutButton = (props: ZoomOutButtonProps) => {
   const {
     label = '축소',
-    icon = <ZoomOutIcon />,
+    icon = <ZoomOutButtonIcon fontSize="small" />,
     onClick,
     className,
     ...rest

--- a/src/renderer/features/graphSlice.ts
+++ b/src/renderer/features/graphSlice.ts
@@ -52,6 +52,8 @@ const graphSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchGraphData.pending, (state, { payload }) => {
       state.loadingMsg = '테라폼 그래프를 불러오는 중입니다.';
+      state.selectedNode = null;
+      state.selectedModule = null;
     });
     builder.addCase(fetchGraphData.fulfilled, (state, { payload }) => {
       state.graphData = payload as GraphData;

--- a/src/renderer/hooks/useGraphProps.ts
+++ b/src/renderer/hooks/useGraphProps.ts
@@ -137,6 +137,8 @@ export const useGraphProps = () => {
 
     if (selectedNode?.id !== node.id) {
       dispatch(setSelectedNode(_.omit(node, ['vx', 'vy'])));
+    } else {
+      dispatch(setSelectedNode(null));
     }
   };
 

--- a/src/renderer/theme/index.js
+++ b/src/renderer/theme/index.js
@@ -14,6 +14,9 @@ const theme = createTheme({
       primary: '#172b4d',
       secondary: '#6b778c',
     },
+    toolbar: {
+      button: '#5b6c7f',
+    },
   },
   shadows: [
     'none',

--- a/src/renderer/theme/theme.d.ts
+++ b/src/renderer/theme/theme.d.ts
@@ -1,0 +1,14 @@
+import { PaletteColor } from '@mui/material';
+
+declare module '@mui/material/styles' {
+  export interface Palette {
+    toolbar: {
+      button: string;
+    };
+  }
+  export interface PaletteOptions {
+    toolbar: {
+      button: string;
+    };
+  }
+}

--- a/src/renderer/types/graph.ts
+++ b/src/renderer/types/graph.ts
@@ -11,7 +11,7 @@ export interface NodeData extends NodeObject {
   type: NodeKind;
   icon: string;
   modules: string[];
-  status?: string;
+  state?: string;
   dataSource?: boolean; // 데이터소스 여부. true면 데이터소스
   parentNodes?: (string | number)[];
   childNodes?: (string | number)[];

--- a/src/renderer/types/graph.ts
+++ b/src/renderer/types/graph.ts
@@ -20,9 +20,10 @@ export interface LinkData extends LinkObject {
   id?: string | number;
 }
 
-export interface ModulePath {
-  id?: string | number;
+export interface ModuleData {
+  root: boolean; // 프로젝트 루트 경로인지 여부. true면 루트
+  id: string | number;
   name: string;
   path: string;
-  size?: number;
+  size: number;
 }

--- a/src/renderer/utils/graph/dot.ts
+++ b/src/renderer/utils/graph/dot.ts
@@ -23,7 +23,7 @@ const getRawNode = (jsonObject: any): NodeData[] => {
 
 const getRawLink = (jsonObject: any): LinkData[] => {
   return jsonObject.edges?.map((link: any) => {
-    return { source: link.tail, target: link.head };
+    return { source: link.head, target: link.tail };
   });
 };
 

--- a/src/renderer/utils/graph/parse.ts
+++ b/src/renderer/utils/graph/parse.ts
@@ -100,16 +100,21 @@ const setNeighborElements = (gData: GraphData) => {
   return gData;
 };
 
-const removeUtilElements = (gData: GraphData) => {
+const removeElements = (gData: GraphData) => {
+  // 그래프 유틸성 노드 및 output & variable 노드 제거
   const utilNodeList = ['root', 'meta.count-boundary (EachMode fixup)'];
+
   let newNodes = _.cloneDeep(gData.nodes) as NodeData[];
   let newLinks = _.cloneDeep(gData.links) as LinkData[];
-  const addLinks: LinkData[] = [];
-  utilNodeList.forEach((fullName) => {
-    const removeNode = newNodes.find(
-      (node) => (node as NodeData).fullName === fullName
-    ) as NodeData;
-    if (removeNode) {
+
+  gData.nodes.forEach((n) => {
+    const removeNode = n as NodeData;
+    if (
+      utilNodeList.includes(removeNode.fullName) ||
+      removeNode.type === 'output' ||
+      removeNode.type === 'var'
+    ) {
+      const addLinks: LinkData[] = [];
       newLinks.forEach((link) => {
         // connecting with a new node
         if (link.source === removeNode.id) {
@@ -129,37 +134,6 @@ const removeUtilElements = (gData: GraphData) => {
     }
   });
   return { nodes: newNodes, links: newLinks };
-};
-
-const removeVarElements = (gData: GraphData) => {
-  let newNodes = _.cloneDeep(gData.nodes) as NodeData[];
-  const newLinks: LinkData[] = [];
-
-  gData.links.forEach((link) => {
-    const { source, target } = link;
-    const sourceNode =
-      source && typeof source !== 'object' && nodesById(newNodes)[source];
-    const targetNode =
-      target && typeof target !== 'object' && nodesById(newNodes)[target];
-    if (
-      sourceNode.type !== 'output' &&
-      sourceNode.type !== 'var' &&
-      targetNode.type !== 'output' &&
-      targetNode.type !== 'var'
-    ) {
-      newLinks.push(link);
-    }
-  });
-
-  newNodes = newNodes.filter(
-    (node) => node.type !== 'output' && node.type !== 'var'
-  );
-
-  return { nodes: newNodes, links: newLinks };
-};
-
-const removeElements = (gData: GraphData) => {
-  return removeVarElements(removeUtilElements(gData));
 };
 
 export const getRefinedGraph = (gData: GraphData) => {


### PR DESCRIPTION
1. 툴바 버튼 디자인 수정

2. 모듈 목록 조회 팝업창 컴포넌트 구현
모듈 이름 및 경로, 오브젝트 갯수를 테이블 형태로 표시. 모듈 이름 선택 시 해당 모듈 이동

3. 그래프 파싱 로직 수정
output & variable 노드 제거 시 hierarchy가 어긋나는 현상 수정
link 방향이 반대로 표시되는 현상 수정
close 상태인 노드 제거