### PR TITLE
[feat] locals, terraform 타입일 경우에 로직 추가

### DIFF
--- a/src/renderer/components/topology/TopologySidePanel.tsx
+++ b/src/renderer/components/topology/TopologySidePanel.tsx
@@ -12,14 +12,15 @@ import FormTabs from './state/StateTabs';
 import preDefinedData from './state/form/utils/preDefinedData';
 import { setSelectedSourceSchema } from '../../features/codeSlice';
 import { TOPOLOGY_TOOLBAR_HEIGHT } from './toolbar/TopologyToolbar';
-import { getObjectType } from './state/form/utils/getResourceInfo';
+import { getObjectType, getId } from './state/form/utils/getResourceInfo';
 
 export const SIDEPANEL_WIDTH = 500;
 // 저장 버튼 누르면 redux objects에 content 덮어씌우기나이ㅓㄻ
 const TopologySidePanel = () => {
   const { type, resourceName, content, sourceSchema, instanceName } =
     useSelector(selectCodeSelectedObjectInfo);
-  const name = getObjectType(type) === 1 ? instanceName : resourceName;
+
+  const id = getId(type, resourceName, instanceName);
 
   const dispatch = useAppDispatch();
   const isSidePanelOpen = useAppSelector(selectUiToggleSidePanel);
@@ -28,7 +29,7 @@ const TopologySidePanel = () => {
     []
   );
   const currentSchema = _.isEmpty(sourceSchema)
-    ? terraformSchemaMap.get(type + '-' + name)
+    ? terraformSchemaMap.get(id)
     : sourceSchema;
   const {
     customUISchema = {},

--- a/src/renderer/components/topology/TopologySidePanel.tsx
+++ b/src/renderer/components/topology/TopologySidePanel.tsx
@@ -12,14 +12,14 @@ import FormTabs from './state/StateTabs';
 import preDefinedData from './state/form/utils/preDefinedData';
 import { setSelectedSourceSchema } from '../../features/codeSlice';
 import { TOPOLOGY_TOOLBAR_HEIGHT } from './toolbar/TopologyToolbar';
-import { hasNotResourceName } from './state/form/utils/getResourceInfo';
+import { getObjectType } from './state/form/utils/getResourceInfo';
 
 export const SIDEPANEL_WIDTH = 500;
 // 저장 버튼 누르면 redux objects에 content 덮어씌우기나이ㅓㄻ
 const TopologySidePanel = () => {
   const { type, resourceName, content, sourceSchema, instanceName } =
     useSelector(selectCodeSelectedObjectInfo);
-  const name = hasNotResourceName(type) ? instanceName : resourceName;
+  const name = getObjectType(type) === 1 ? instanceName : resourceName;
 
   const dispatch = useAppDispatch();
   const isSidePanelOpen = useAppSelector(selectUiToggleSidePanel);
@@ -34,7 +34,17 @@ const TopologySidePanel = () => {
     customUISchema = {},
     formData = {},
     fixedSchema = {},
-  } = instanceName && preDefinedData(currentSchema, content, type);
+  } = React.useMemo(
+    () => preDefinedData(currentSchema, content, type),
+    [currentSchema, content, type]
+  );
+  const title = React.useMemo(() => {
+    if (getObjectType(type) === 0) {
+      return type;
+    } else {
+      return instanceName;
+    }
+  }, [type, instanceName]);
   React.useEffect(() => {
     dispatch(setSelectedSourceSchema(fixedSchema));
   }, [instanceName]);
@@ -54,7 +64,7 @@ const TopologySidePanel = () => {
         anchor="right"
         variant="persistent"
       >
-        <FormHeader title={instanceName} resourceName={resourceName} />
+        <FormHeader title={title} resourceName={resourceName} />
         <FormTabs
           schema={fixedSchema}
           formData={formData}

--- a/src/renderer/components/topology/TopologySidebar.tsx
+++ b/src/renderer/components/topology/TopologySidebar.tsx
@@ -22,7 +22,7 @@ import { selectCodeFileObjects } from '@renderer/features/codeSliceInputSelector
 import parseToCustomizeKey from './state/form/utils/parseToCustomizeKey';
 import {
   getObjectNameInfo,
-  hasNotResourceName,
+  getObjectType,
 } from './state/form/utils/getResourceInfo';
 import {
   openExistFolder,
@@ -141,28 +141,52 @@ const TopologySidebar = () => {
   // useSelector로 반환한 배열에 대해 반복문을 돌면서 objResult를 변경시킴... refactor할 예정
   const fileObjects = useAppSelector(selectCodeFileObjects);
   // [TODO] Error나서 string으로 들어올 때 Error 표시 기획 필요할듯
+
   Array.isArray(fileObjects) &&
     fileObjects.forEach((file: { filePath: string; fileJson: any }) => {
       // eslint-disable-next-line guard-for-in
       for (const currKey in file.fileJson) {
-        if (hasNotResourceName(currKey)) {
-          objResult.push(
-            ..._.entries(file.fileJson[currKey]).map((object) => ({
-              [object[0]]: object[1],
-              type: currKey,
-              resourceName: '',
-            }))
-          );
-        } else {
-          Object.keys(file.fileJson[currKey]).forEach((key) => {
+        switch (getObjectType(currKey)) {
+          case 2: {
+            Object.keys(file.fileJson[currKey]).forEach((key) => {
+              objResult.push(
+                ..._.entries(file.fileJson[currKey][key]).map((object) => {
+                  return {
+                    [object[0]]: object[1],
+                    type: currKey,
+                    resourceName: key,
+                    instanceName: object[0],
+                  };
+                })
+              );
+            });
+            break;
+          }
+          case 1: {
             objResult.push(
-              ..._.entries(file.fileJson[currKey][key]).map((object) => ({
-                [object[0]]: object[1],
+              ..._.entries(file.fileJson[currKey]).map((object) => {
+                return {
+                  [object[0]]: object[1],
+                  type: currKey,
+                  resourceName: '',
+                  instanceName: object[0],
+                };
+              })
+            );
+            break;
+          }
+          case 0: {
+            objResult.push(
+              ..._.entries(file.fileJson[currKey]).map((object) => ({
+                [currKey]: { [object[0]]: object[1] },
                 type: currKey,
-                resourceName: key,
+                resourceName: '',
+                instanceName: '',
               }))
             );
-          });
+            break;
+          }
+          default:
         }
       }
     });

--- a/src/renderer/components/topology/TopologySidebar.tsx
+++ b/src/renderer/components/topology/TopologySidebar.tsx
@@ -142,52 +142,56 @@ const TopologySidebar = () => {
   const fileObjects = useAppSelector(selectCodeFileObjects);
   // [TODO] Error나서 string으로 들어올 때 Error 표시 기획 필요할듯
 
+  const setObjResult = (file: any, type: string) => {
+    switch (getObjectType(type)) {
+      case 2: {
+        Object.keys(file.fileJson[type]).forEach((resourceName) => {
+          objResult.push(
+            ..._.entries(file.fileJson[type][resourceName]).map((object) => {
+              return {
+                [object[0]]: object[1],
+                type,
+                resourceName,
+                instanceName: object[0],
+              };
+            })
+          );
+        });
+        break;
+      }
+      case 1: {
+        objResult.push(
+          ..._.entries(file.fileJson[type]).map((object) => {
+            return {
+              [object[0]]: object[1],
+              type,
+              resourceName: '',
+              instanceName: object[0],
+            };
+          })
+        );
+        break;
+      }
+      case 0: {
+        objResult.push(
+          ..._.entries(file.fileJson[type]).map((object) => ({
+            [type]: { [object[0]]: object[1] },
+            type,
+            resourceName: '',
+            instanceName: '',
+          }))
+        );
+        break;
+      }
+      default:
+    }
+  };
+
   Array.isArray(fileObjects) &&
     fileObjects.forEach((file: { filePath: string; fileJson: any }) => {
       // eslint-disable-next-line guard-for-in
-      for (const currKey in file.fileJson) {
-        switch (getObjectType(currKey)) {
-          case 2: {
-            Object.keys(file.fileJson[currKey]).forEach((key) => {
-              objResult.push(
-                ..._.entries(file.fileJson[currKey][key]).map((object) => {
-                  return {
-                    [object[0]]: object[1],
-                    type: currKey,
-                    resourceName: key,
-                    instanceName: object[0],
-                  };
-                })
-              );
-            });
-            break;
-          }
-          case 1: {
-            objResult.push(
-              ..._.entries(file.fileJson[currKey]).map((object) => {
-                return {
-                  [object[0]]: object[1],
-                  type: currKey,
-                  resourceName: '',
-                  instanceName: object[0],
-                };
-              })
-            );
-            break;
-          }
-          case 0: {
-            objResult.push(
-              ..._.entries(file.fileJson[currKey]).map((object) => ({
-                [currKey]: { [object[0]]: object[1] },
-                type: currKey,
-                resourceName: '',
-                instanceName: '',
-              }))
-            );
-            break;
-          }
-          default:
-        }
+      for (const type in file.fileJson) {
+        setObjResult(file, type);
       }
     });
 

--- a/src/renderer/components/topology/object/TopologyObject.tsx
+++ b/src/renderer/components/topology/object/TopologyObject.tsx
@@ -127,6 +127,44 @@ const TopologyObject = (props: TopologyObjectProps) => {
       ),
     },
   ];
+  const filterObjList = (
+    type: string,
+    item: Item,
+    resourceName: string,
+    instanceName: string
+  ) => {
+    switch (getObjectType(type)) {
+      case 2: {
+        return (
+          item.instanceName === instanceName &&
+          item.resourceName === resourceName
+        );
+      }
+      case 1: {
+        return item.instanceName === instanceName;
+      }
+      case 0: {
+        return item.type === type;
+      }
+      default:
+        return false;
+    }
+  };
+
+  const getObject = (type: string, obj: any, instanceName: string) => {
+    switch (getObjectType(type)) {
+      case 2: {
+        return obj[instanceName];
+      }
+      case 1: {
+        return obj[instanceName];
+      }
+      case 0: {
+        return obj[type];
+      }
+      default:
+    }
+  };
 
   const handleClick = (
     event: React.MouseEvent<any>,
@@ -134,38 +172,13 @@ const TopologyObject = (props: TopologyObjectProps) => {
     item: Item
   ) => {
     const selectedObj = objResult.filter((cur: any) => {
-      const { type, resourceName, instanceName, ...obj } = cur;
-      switch (getObjectType(type)) {
-        case 2: {
-          return (
-            item.instanceName === instanceName &&
-            item.resourceName === resourceName
-          );
-        }
-        case 1: {
-          return item.instanceName === instanceName;
-        }
-        case 0: {
-          return item.type === type;
-        }
-        default:
-      }
+      const { type, resourceName, instanceName } = cur;
+      return filterObjList(type, item, resourceName, instanceName);
     })[0];
 
     const { type, resourceName, instanceName, ...obj } = selectedObj;
     const content = (type: string) => {
-      switch (getObjectType(type)) {
-        case 2: {
-          return obj[instanceName];
-        }
-        case 1: {
-          return obj[instanceName];
-        }
-        case 0: {
-          return obj[type];
-        }
-        default:
-      }
+      return getObject(type, obj, instanceName);
     };
 
     const object = {

--- a/src/renderer/components/topology/state/form/AddFieldSection.tsx
+++ b/src/renderer/components/topology/state/form/AddFieldSection.tsx
@@ -22,7 +22,7 @@ import { ArrowDropDown } from '@mui/icons-material';
 import { useAppDispatch, useAppSelector } from '@renderer/app/store';
 import { selectCodeSelectedObjectInfo } from '@renderer/features/codeSliceInputSelectors';
 import { addSchemaBasedField, addCustomField } from './utils/addInputField';
-import { getObjectType } from './utils/getResourceInfo';
+import { getId } from './utils/getResourceInfo';
 
 const useStyles: any = makeStyles((theme) =>
   createStyles({
@@ -76,11 +76,9 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
     );
   };
 
-  const name = getObjectType(type) === 1 ? instanceName : resourceName;
+  const id = getId(type, resourceName, instanceName);
   React.useEffect(() => {
-    const schema: JSONSchema7 = terraformSchemaMap.get(
-      type + '-' + name
-    ) as JSONSchema7;
+    const schema: JSONSchema7 = terraformSchemaMap.get(id) as JSONSchema7;
     schema
       ? setCurrentSchemaList(initSchemaList(schema) as string[])
       : setCurrentSchemaList([]);

--- a/src/renderer/components/topology/state/form/AddFieldSection.tsx
+++ b/src/renderer/components/topology/state/form/AddFieldSection.tsx
@@ -22,7 +22,7 @@ import { ArrowDropDown } from '@mui/icons-material';
 import { useAppDispatch, useAppSelector } from '@renderer/app/store';
 import { selectCodeSelectedObjectInfo } from '@renderer/features/codeSliceInputSelectors';
 import { addSchemaBasedField, addCustomField } from './utils/addInputField';
-import { hasNotResourceName } from './utils/getResourceInfo';
+import { getObjectType } from './utils/getResourceInfo';
 
 const useStyles: any = makeStyles((theme) =>
   createStyles({
@@ -76,15 +76,10 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
     );
   };
 
-  const getTerraformMapId = (type: string) => {
-    if (hasNotResourceName(type)) {
-      return type + '-' + instanceName;
-    }
-    return type + '-' + resourceName;
-  };
+  const name = getObjectType(type) === 1 ? instanceName : resourceName;
   React.useEffect(() => {
     const schema: JSONSchema7 = terraformSchemaMap.get(
-      getTerraformMapId(type)
+      type + '-' + name
     ) as JSONSchema7;
     schema
       ? setCurrentSchemaList(initSchemaList(schema) as string[])

--- a/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
+++ b/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash-es';
 const KEY_DELIMETER = '**##**';
 
 export const noResourceNameTypeList = [
@@ -9,8 +10,29 @@ export const noResourceNameTypeList = [
   'locals',
 ];
 
-export const hasNotResourceName = (type: string) =>
-  !!noResourceNameTypeList.find((currType) => type === currType);
+export const noInstanceNameTypeList = ['terraform', 'locals'];
+
+export const getObjectType = (type: string) => {
+  if (_.findIndex(noResourceNameTypeList, (cur) => cur === type) < 0) {
+    // resource || datasource
+    // resourceName이랑 instanceName 두개 다 있으니까 2 반환
+    return 2;
+  } else if (
+    _.findIndex(
+      _.xor(noResourceNameTypeList, noInstanceNameTypeList),
+      (cur) => cur === type
+    ) >= 0
+  ) {
+    // module || provider || variable || output
+    //  instanceName 하나있으니까 1 반환
+    return 1;
+  } else if (_.findIndex(noInstanceNameTypeList, (cur) => cur === type) >= 0) {
+    // terraform || locals
+    // resourceName이랑 instanceName 두개 다 없으니까 0 반환
+    return 0;
+  }
+  return -1; // 해당 사항 없을 때 (error)
+};
 
 export const getObjectNameInfo = (object: any, type: string) => {
   return { instanceName: Object.keys(object)[0] };

--- a/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
+++ b/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
@@ -39,9 +39,9 @@ export const getId = (
   instanceName: string
 ) => {
   if (getObjectType(type) === 1) {
-    return instanceName;
+    return type + '-' + instanceName;
   }
-  return resourceName;
+  return type + '-' + resourceName;
 };
 
 export const getObjectNameInfo = (object: any, type: string) => {

--- a/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
+++ b/src/renderer/components/topology/state/form/utils/getResourceInfo.ts
@@ -33,6 +33,16 @@ export const getObjectType = (type: string) => {
   }
   return -1; // 해당 사항 없을 때 (error)
 };
+export const getId = (
+  type: string,
+  resourceName: string,
+  instanceName: string
+) => {
+  if (getObjectType(type) === 1) {
+    return instanceName;
+  }
+  return resourceName;
+};
 
 export const getObjectNameInfo = (object: any, type: string) => {
   return { instanceName: Object.keys(object)[0] };

--- a/src/renderer/components/topology/state/form/utils/parseToCustomizeKey.ts
+++ b/src/renderer/components/topology/state/form/utils/parseToCustomizeKey.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import { JSONSchema7 } from 'json-schema';
 import { getSchemaMap } from '@renderer/utils/storageAPI';
-import { hasNotResourceName, getObjectNameInfo } from './getResourceInfo';
+import { getObjectNameInfo, getObjectType } from './getResourceInfo';
 import preDefinedFileObjects from './preDefinedFileObjects';
 
 const parseToCustomizeKey = (fileObjects: any[]) => {
@@ -16,18 +16,29 @@ const parseToCustomizeKey = (fileObjects: any[]) => {
             resourceValue,
             resourceType
           );
-          const id = hasNotResourceName(resourceType)
-            ? resourceType + '-' + instanceName
-            : resourceType + '-' + resourceName;
+          const name =
+            getObjectType(resourceType) === 1 ? instanceName : resourceName;
+          const id = resourceType + '-' + name;
           const currentSchema = terraformSchemaMap.get(id);
-          const content = hasNotResourceName(resourceType)
-            ? resourceValue
-            : Object.values(resourceValue as any)[0];
+          const content = (type: string) => {
+            switch (getObjectType(type)) {
+              case 2: {
+                return Object.values(resourceValue as any)[0];
+              }
+              case 1: {
+                return resourceValue;
+              }
+              case 0: {
+                return { [resourceName]: resourceValue };
+              }
+              default:
+            }
+          };
           const mapObjectTypeList = currentSchema
             ? preDefinedFileObjects(
                 resourceType,
                 currentSchema as JSONSchema7,
-                content,
+                content(resourceType),
                 resourceName,
                 Object.keys(resourceValue as any)[0]
               )

--- a/src/renderer/components/topology/state/form/utils/parseToCustomizeKey.ts
+++ b/src/renderer/components/topology/state/form/utils/parseToCustomizeKey.ts
@@ -1,8 +1,23 @@
 import * as _ from 'lodash-es';
 import { JSONSchema7 } from 'json-schema';
 import { getSchemaMap } from '@renderer/utils/storageAPI';
-import { getObjectNameInfo, getObjectType } from './getResourceInfo';
+import { getObjectNameInfo, getObjectType, getId } from './getResourceInfo';
 import preDefinedFileObjects from './preDefinedFileObjects';
+
+const getContent = (type: string, object: any) => {
+  switch (getObjectType(type)) {
+    case 2: {
+      return Object.values(Object.values(object as any)[0] as any)[0];
+    }
+    case 1: {
+      return Object.values(object as any)[0];
+    }
+    case 0: {
+      return object;
+    }
+    default:
+  }
+};
 
 const parseToCustomizeKey = (fileObjects: any[]) => {
   const terraformSchemaMap = getSchemaMap();
@@ -16,23 +31,10 @@ const parseToCustomizeKey = (fileObjects: any[]) => {
             resourceValue,
             resourceType
           );
-          const name =
-            getObjectType(resourceType) === 1 ? instanceName : resourceName;
-          const id = resourceType + '-' + name;
+          const id = getId(resourceType, resourceName, instanceName);
           const currentSchema = terraformSchemaMap.get(id);
           const content = (type: string) => {
-            switch (getObjectType(type)) {
-              case 2: {
-                return Object.values(resourceValue as any)[0];
-              }
-              case 1: {
-                return resourceValue;
-              }
-              case 0: {
-                return { [resourceName]: resourceValue };
-              }
-              default:
-            }
+            getContent(type, resource);
           };
           const mapObjectTypeList = currentSchema
             ? preDefinedFileObjects(

--- a/src/renderer/components/topology/state/form/utils/preDefinedFileObjects.ts
+++ b/src/renderer/components/topology/state/form/utils/preDefinedFileObjects.ts
@@ -1,4 +1,3 @@
-import { current } from 'immer';
 import { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 


### PR DESCRIPTION
locals랑 terraform 타입일 경우에는 resourceName이랑 instanceName 둘다 없음

-> 기존에 있던 hasNotResourceName 함수 제거
=> resourceName이 있는 경우랑 없는 경우로만 나뉘는 줄 알았는데 둘다 없는 경우가 있다는 걸 이제 깨우침. 

-> hasNotResourceName 대신 getObjectType 유틸 함수 추가함
=> 우선 해당 함수가 반환하는 반환값도 2,1,0 으로 다소 가독성이 없음 (혹시 아이디어 있으면 피드백 줬으면 좋을듯)
=> getObjectType을 사용하는 부분도 case가 3개라서 switch문으로 했는데 다른 좋은 아이디어 있으면 피드백 줬으면 좋을듯..