### PR TITLE
[feat] 테라폼 init/graph 실행 경로 수정 및 디렉토리 복사 유틸 구현

### DIFF
--- a/src/main/base/common/fileUtils.ts
+++ b/src/main/base/common/fileUtils.ts
@@ -18,6 +18,19 @@ export function makeDir(dirPath: string) {
   }
 }
 
+export function copyDir(source: string, destination: string) {
+  fs.mkdirSync(destination, { recursive: true });
+
+  fs.readdirSync(source, { withFileTypes: true }).forEach((entry) => {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+
+    entry.isDirectory()
+      ? copyDir(sourcePath, destinationPath)
+      : fs.copyFileSync(sourcePath, destinationPath);
+  });
+}
+
 export function createFile(resourcePath: string) {
   const dirname = path.dirname(resourcePath);
   if (!fs.existsSync(dirname)) {

--- a/src/main/terraform-command/electron-main/terraformMainService.ts
+++ b/src/main/terraform-command/electron-main/terraformMainService.ts
@@ -230,13 +230,13 @@ export class TerraformMainService {
           };
         }
         */
-        const uri =
-          this.workspaceMainService.workspaceManagementService.getRealOrTempFolderPath(
+        const folderUri =
+          this.workspaceMainService.workspaceManagementService.getWorkspaceTemporaryFolderPath(
             workspaceUid
           );
         try {
           // MEMO : 현재는 tfExePath 값은 사용안하고있어서 그냥 공백으로 넘겨줌.
-          await this.doTerraformInit(uri, '', event);
+          await this.doTerraformInit(folderUri, '', event);
           return {
             status: TerraformStatusType.SUCCESS,
             data: TerraformStatusType.SUCCESS,
@@ -266,8 +266,8 @@ export class TerraformMainService {
         }
         */
 
-        const uri =
-          this.workspaceMainService.workspaceManagementService.getRealOrTempFolderPath(
+        const folderUri =
+          this.workspaceMainService.workspaceManagementService.getWorkspaceTemporaryFolderPath(
             workspaceUid
           );
 
@@ -275,7 +275,7 @@ export class TerraformMainService {
         // MEMO : 현재는 tfExePath 값은 사용안하고있어서 그냥 공백으로 넘겨줌.
         // MEMO : 워크스페이스 설정마다 다른 terraform.exe 실행시켜주려면 위와 아래부분 주석처리부분 사용하기
         try {
-          const graphData: string = await this.doTerraformGraph(uri, '');
+          const graphData: string = await this.doTerraformGraph(folderUri, '');
           return {
             status: TerraformStatusType.SUCCESS,
             data: { graphData },

--- a/src/main/terraform-command/electron-main/terraformMainService.ts
+++ b/src/main/terraform-command/electron-main/terraformMainService.ts
@@ -163,7 +163,7 @@ export class TerraformMainService {
         graphData += chunk;
         // graphData += iconv.decode(chunk, 'euc-kr');
       }
-      console.log('graphData: ', graphData);
+      // console.log('graphData: ', graphData);
 
       let graphError = '';
       for await (const chunk of graphCmd.stderr) {
@@ -220,10 +220,6 @@ export class TerraformMainService {
       'studio:doTerraformInit',
       async (event, arg: TerraformInitArgs): Promise<TerraformResponse> => {
         const { workspaceUid } = arg;
-        const workspaceConfig: WorkspaceIdentifier =
-          this.workspaceMainService.workspaceManagementService.getWorkspaceConfig(
-            workspaceUid
-          );
         // MEMO : 워크스페이스별로 테라폼 exe경로 다르게 설정하는 기능 추가되면 아래 주석처리 풀어서 path 유효성도 체크하기
         /*
         const tfExePath = workspaceConfig.terraformExePath || 'EMPTY';
@@ -234,10 +230,13 @@ export class TerraformMainService {
           };
         }
         */
-        const folderUri = workspaceConfig.workspaceRealPath;
+        const uri =
+          this.workspaceMainService.workspaceManagementService.getRealOrTempFolderPath(
+            workspaceUid
+          );
         try {
           // MEMO : 현재는 tfExePath 값은 사용안하고있어서 그냥 공백으로 넘겨줌.
-          await this.doTerraformInit(folderUri, '', event);
+          await this.doTerraformInit(uri, '', event);
           return {
             status: TerraformStatusType.SUCCESS,
             data: TerraformStatusType.SUCCESS,
@@ -256,10 +255,6 @@ export class TerraformMainService {
       'studio:getTerraformGraph',
       async (event, arg: TerraformGraphArgs): Promise<TerraformResponse> => {
         const { workspaceUid } = arg;
-        const workspaceConfig: WorkspaceIdentifier =
-          this.workspaceMainService.workspaceManagementService.getWorkspaceConfig(
-            workspaceUid
-          );
         // MEMO : 워크스페이스별로 테라폼 exe경로 다르게 설정하는 기능 추가되면 아래 주석처리 풀어서 path 유효성도 체크하기
         /*
         const tfExePath = workspaceConfig.terraformExePath || 'EMPTY';
@@ -271,12 +266,16 @@ export class TerraformMainService {
         }
         */
 
-        const folderUri = workspaceConfig.workspaceRealPath;
+        const uri =
+          this.workspaceMainService.workspaceManagementService.getRealOrTempFolderPath(
+            workspaceUid
+          );
+
         // MEMO : 시스템 환경변수로 Path에 설정돼있는 terraform.exe만 실행시키도록 임시 처리.
         // MEMO : 현재는 tfExePath 값은 사용안하고있어서 그냥 공백으로 넘겨줌.
         // MEMO : 워크스페이스 설정마다 다른 terraform.exe 실행시켜주려면 위와 아래부분 주석처리부분 사용하기
         try {
-          const graphData: string = await this.doTerraformGraph(folderUri, '');
+          const graphData: string = await this.doTerraformGraph(uri, '');
           return {
             status: TerraformStatusType.SUCCESS,
             data: { graphData },

--- a/src/main/workspaces/common/workspace.ts
+++ b/src/main/workspaces/common/workspace.ts
@@ -106,6 +106,9 @@ export interface WorkspaceManagementServiceInterface {
   getWorkspaceConfig(uid: string): any;
   generateDefaultNewWorkspaceName(): string;
   setWorkspaceConfigItem(uid: string, key: string, data: any): void;
+  getWorkspaceTemporaryFolderPath(workspaceId: string): string;
+  getRealOrTempFolderPath(workspaceId: string): string;
+  copyRealToTempFolder(workspaceId: string): void;
 }
 export interface WorkspacesHistoryServiceInterface {
   addWorkspaceToStorage(folderUri: string): void;

--- a/src/main/workspaces/common/workspace.ts
+++ b/src/main/workspaces/common/workspace.ts
@@ -107,7 +107,6 @@ export interface WorkspaceManagementServiceInterface {
   generateDefaultNewWorkspaceName(): string;
   setWorkspaceConfigItem(uid: string, key: string, data: any): void;
   getWorkspaceTemporaryFolderPath(workspaceId: string): string;
-  getRealOrTempFolderPath(workspaceId: string): string;
   copyRealToTempFolder(workspaceId: string): void;
 }
 export interface WorkspacesHistoryServiceInterface {

--- a/src/main/workspaces/electron-main/workspaceConvertService.ts
+++ b/src/main/workspaces/electron-main/workspaceConvertService.ts
@@ -2,10 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import * as FileUtils from '../../base/common/fileUtils';
 import * as WorkspaceTypes from '../common/workspace';
-import {
-  WorkspaceManagementService,
-  getWorkspaceTemporaryFolderPath,
-} from './workspaceManagementService';
+import { WorkspaceManagementService } from './workspaceManagementService';
 const Converter = require('../../utils/hcljsonconverter');
 
 export class WorkspaceConvertService
@@ -47,7 +44,8 @@ export class WorkspaceConvertService
       workspaceUid
     ) as string;
     const temporaryDataFolderUri =
-      getWorkspaceTemporaryFolderPath(workspaceUid);
+      workspaceManagementService.getWorkspaceTemporaryFolderPath(workspaceUid);
+
     objList.forEach((obj) => {
       const { fileJson, filePath } = obj;
 

--- a/src/main/workspaces/electron-main/workspaceMainService.ts
+++ b/src/main/workspaces/electron-main/workspaceMainService.ts
@@ -156,6 +156,7 @@ export class WorkspaceMainService
           ) {
             const uid = await this.getWorkspaceMetaOfExistFolder(folderUri);
             this.workspacesHistoryService.addWorkspaceToStorage(folderUri);
+            this.workspaceManagementService.copyRealToTempFolder(uid);
             return {
               status: WorkspaceTypes.WorkspaceStatusType.SUCCESS,
               data: { uid },

--- a/src/main/workspaces/electron-main/workspaceManagementService.ts
+++ b/src/main/workspaces/electron-main/workspaceManagementService.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import {
+  copyDir,
   createFile,
   readFileJson,
   writeFileJson,
@@ -24,14 +25,6 @@ export const workspaceMapPath = path.join(
 );
 export const getWorkspaceConfigPath = (uid: string) => {
   return path.join(getWorkspaceMetaFolderPath(), uid, WORKSPACE_CONFIG_PATH);
-};
-
-export const getWorkspaceTemporaryFolderPath = (uid: string) => {
-  return path.join(
-    getWorkspaceMetaFolderPath(),
-    uid,
-    TEMPORARYDATA_FOLDER_PATH
-  );
 };
 
 export class WorkspaceManagementService
@@ -206,5 +199,26 @@ export class WorkspaceManagementService
       }
     }
     return newWorkspaceName;
+  }
+
+  getWorkspaceTemporaryFolderPath(workspaceId: string): string {
+    return path.join(
+      getWorkspaceMetaFolderPath(),
+      workspaceId,
+      TEMPORARYDATA_FOLDER_PATH
+    );
+  }
+
+  getRealOrTempFolderPath(workspaceId: string): string {
+    const folderPath = this.getWorkspaceConfig(workspaceId).workspaceRealPath;
+    const tempFolderPath = this.getWorkspaceTemporaryFolderPath(workspaceId);
+    const path = fs.existsSync(tempFolderPath) ? tempFolderPath : folderPath;
+    return path;
+  }
+
+  copyRealToTempFolder(workspaceId: string): void {
+    const folderPath = this.getWorkspaceConfig(workspaceId).workspaceRealPath;
+    const tempFolderPath = this.getWorkspaceTemporaryFolderPath(workspaceId);
+    copyDir(folderPath, tempFolderPath);
   }
 }

--- a/src/main/workspaces/electron-main/workspaceManagementService.ts
+++ b/src/main/workspaces/electron-main/workspaceManagementService.ts
@@ -209,13 +209,6 @@ export class WorkspaceManagementService
     );
   }
 
-  getRealOrTempFolderPath(workspaceId: string): string {
-    const folderPath = this.getWorkspaceConfig(workspaceId).workspaceRealPath;
-    const tempFolderPath = this.getWorkspaceTemporaryFolderPath(workspaceId);
-    const path = fs.existsSync(tempFolderPath) ? tempFolderPath : folderPath;
-    return path;
-  }
-
   copyRealToTempFolder(workspaceId: string): void {
     const folderPath = this.getWorkspaceConfig(workspaceId).workspaceRealPath;
     const tempFolderPath = this.getWorkspaceTemporaryFolderPath(workspaceId);


### PR DESCRIPTION
- terraform init 및 graph 커맨드 실행하는 파일 경로 수정: 임시 경로에서 수행하는 것으로 변경
-  getWorkspaceTemporaryFolderPath API를 WorkspaceManagementServiceInterface에서 참조하도록 수정
- getRealOrTempFolderPath API, copyRealToTempFolder API 추가
- copyDir: 디렉토리 복사에 대한 파일 유틸 추가
