### PR TITLE
[bugfix] TopologyLibrary 에서 임시 directory 로 export 할때 새로 생성한 object 하고 있어서 수정함

### DIFF
--- a/src/renderer/components/topology/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/TopologyLibrary.tsx
@@ -199,22 +199,42 @@ const ShowItemList: React.FC<ShowItemListProps> = ({ items, title }) => {
                         } else if (item.type === 'default') {
                           const newInstanceName =
                             item.resourceName + '-' + fileObjects.length;
-                          const newFileObjects = [
-                            {
-                              filePath:
-                                `${folderUri}` +
-                                path.sep +
-                                `${newInstanceName}.tf`,
-                              fileJson: {
-                                [item.resourceName]: {
-                                  [newInstanceName]: addedObjectJSON,
+                          let newFileObject;
+                          if (
+                            item.resourceName === 'terraform' ||
+                            item.resourceName === 'locals'
+                          ) {
+                            newFileObject = [
+                              {
+                                filePath:
+                                  `${folderUri}` +
+                                  path.sep +
+                                  `${newInstanceName}.tf`,
+                                fileJson: {
+                                  [item.resourceName]: {
+                                    [newInstanceName]: addedObjectJSON,
+                                  },
                                 },
                               },
-                            },
-                          ];
-                          dispatch(
-                            setFileObjects(fileObjects.concat(newFileObjects))
-                          );
+                            ];
+                          } else {
+                            newFileObject = [
+                              {
+                                filePath:
+                                  `${folderUri}` +
+                                  path.sep +
+                                  `${newInstanceName}.tf`,
+                                fileJson: {
+                                  [item.resourceName]: {
+                                    [newInstanceName]: addedObjectJSON,
+                                  },
+                                },
+                              },
+                            ];
+                          }
+                          const newFileObjects =
+                            fileObjects.concat(newFileObject);
+                          dispatch(setFileObjects(newFileObjects));
                           const object = {
                             type: item.resourceName,
                             resourceName: '',
@@ -266,7 +286,7 @@ const ShowItemList: React.FC<ShowItemListProps> = ({ items, title }) => {
                             item.resourceName +
                             '-' +
                             fileObjects.length;
-                          const newFileObjects = [
+                          const newFileObject = [
                             {
                               filePath:
                                 `${folderUri}` +
@@ -281,9 +301,9 @@ const ShowItemList: React.FC<ShowItemListProps> = ({ items, title }) => {
                               },
                             },
                           ];
-                          dispatch(
-                            setFileObjects(fileObjects.concat(newFileObjects))
-                          );
+                          const newFileObjects =
+                            fileObjects.concat(newFileObject);
+                          dispatch(setFileObjects(newFileObjects));
                           const object = {
                             type: item.type,
                             resourceName: item.resourceName,


### PR DESCRIPTION
1. 임시저장으로 새로 생성한 fileObject만 보내는 문제 수정
2. terraform, locals 등 1depth object case 고려