### PR TITLE
[BUGFIX] 새로운 프로젝트 생성 할 때 폴더 경로에 생성하는 폴더가 포함안되어서 생성되던 버그 수정

### DIFF
--- a/src/renderer/components/workspace/CreateWorkspaceModal.tsx
+++ b/src/renderer/components/workspace/CreateWorkspaceModal.tsx
@@ -225,7 +225,7 @@ const CreateWorkspaceModal: React.FC<CreateWorkspaceModalProps> = ({
           const uid = (data as WorkspaceSuccessUidData)?.uid;
           if (uid) {
             closeModal();
-            openWorkspace(newProjectPath);
+            openWorkspace(newProjectPath.concat('\\', newProjectName));
           }
         } else if (status === WorkspaceStatusType.ERROR_FILE_EXISTS) {
           setPrjNameErrMsg('이미 존재하는 프로젝트 이름입니다.');


### PR DESCRIPTION
- 최경열팀장님이 슬랙으로 문의주신 새로운 프로젝트 생성했을 때 에러가 나는 원인
  - 어제 본부장님 방에서 시연했을 때 폴더 생성한 곳에서 동작이 안이루어지고 한 depth낮은 부분에다가 저장 됬었던 이슈도 이게 원인으로 추정됨