### PR TITLE
라이브러리 탭 리팩토링

### DIFF
--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -4,34 +4,35 @@ import { Box, MenuItem, InputLabel, Select, TextField } from '@mui/material';
 import { Delete } from '@mui/icons-material';
 import { useAppSelector } from '@renderer/app/store';
 import { selectCodeFileObjects } from '@renderer/features/codeSliceInputSelectors';
+import { TerraformType } from '@renderer/types/terraform';
 import TopologyLibararyItemList from './TopologyLibraryItemList';
 import parseJson from '../state/form/utils/json2JsonSchemaParser';
 
-const defaultList = [
+const defaultList: Item[] = [
   {
     title: 'defaults-provider',
     resourceName: 'provider',
-    type: 'default',
+    type: 'provider',
   },
   {
     title: 'defaults-variable',
     resourceName: 'variable',
-    type: 'default',
+    type: 'variable',
   },
   {
     title: 'defaults-output',
     resourceName: 'output',
-    type: 'default',
+    type: 'output',
   },
   {
     title: 'defaults-terraform',
     resourceName: 'terraform',
-    type: 'default',
+    type: 'terraform',
   },
   {
     title: 'defaults-locals',
     resourceName: 'locals',
-    type: 'default',
+    type: 'locals',
   },
 ];
 
@@ -67,7 +68,7 @@ interface Item {
   title: string;
   instanceName?: string;
   resourceName: string;
-  type: string;
+  type: TerraformType;
   source?: string | any;
   version?: string;
   isLocalModule?: boolean;

--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -7,7 +7,7 @@ import { selectCodeFileObjects } from '@renderer/features/codeSliceInputSelector
 import TopologyLibararyItemList, { Item } from './TopologyLibraryItemList';
 import {
   Provider,
-  ProviderList,
+  providerList,
   resourceMap,
   datasourceMap,
 } from './TopologyLibrarySchema';
@@ -164,7 +164,7 @@ const TopologyLibrary = () => {
     let tempResourceItmes: Item[] = [];
     let tempDatasourceItmes: Item[] = [];
 
-    if (provider === 'aws' || provider === 'tls') {
+    if (providerList.indexOf(provider)) {
       tempResourceItmes = resourceMap.get(provider);
       tempDatasourceItmes = datasourceMap.get(provider);
     } else {

--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -5,7 +5,12 @@ import { Delete } from '@mui/icons-material';
 import { useAppSelector } from '@renderer/app/store';
 import { selectCodeFileObjects } from '@renderer/features/codeSliceInputSelectors';
 import TopologyLibararyItemList, { Item } from './TopologyLibraryItemList';
-import { Provider, resourceMap, datasourceMap } from './TopologyLibrarySchema';
+import {
+  Provider,
+  ProviderList,
+  resourceMap,
+  datasourceMap,
+} from './TopologyLibrarySchema';
 
 const defaultList: Item[] = [
   {
@@ -35,6 +40,7 @@ const defaultList: Item[] = [
   },
 ];
 
+//fuzzy search? 비슷한 문자열 검색으로 변경 필요
 function searchByName(searchText: string, name: string) {
   if (name.toUpperCase().indexOf(searchText.toUpperCase()) !== -1) {
     return true;
@@ -152,17 +158,8 @@ const TopologyLibrary = () => {
       tempResourceItmes = [];
       tempDatasourceItmes = [];
     }
-    //setResourceItems(tempResourceItmes);
-    //setDatasourceItems(tempDatasourceItmes);
     //setTerraformModuleItems(moduleList);
 
-    /*
-    if (resourceItems.length || datasourceItems.length) {
-      setIsSearchResultEmpty(false);
-    } else {
-      setIsSearchResultEmpty(true);
-    }
-    */
     selectedProvider = provider;
     setSearchText('');
 
@@ -183,17 +180,6 @@ const TopologyLibrary = () => {
       tempResourceItmes = [];
       tempDatasourceItmes = [];
     }
-    //setResourceItems(tempResourceItmes);
-    //setDatasourceItems(tempDatasourceItmes);
-    //setTerraformModuleItems(moduleList);
-
-    /*
-    if (resourceItems.length || datasourceItems.length) {
-      setIsSearchResultEmpty(false);
-    } else {
-      setIsSearchResultEmpty(true);
-    }
-    */
 
     setResourceItems(
       tempResourceItmes.filter((item) => {
@@ -227,14 +213,13 @@ const TopologyLibrary = () => {
           displayEmpty
           style={{ marginTop: '10px' }}
         >
-          <MenuItem value="aws">AWS</MenuItem>
-          <MenuItem value="tls">TLS</MenuItem>
-          {/*
-          <MenuItem value="azure">Microsoft Azure</MenuItem>
-          <MenuItem value="gcp">Google Cloud Platform</MenuItem>
-          <MenuItem value="openstack">OpenStack</MenuItem>
-          <MenuItem value="vmware">Vmware vSphere</MenuItem>
-          */}
+          {ProviderList.map((provider) => {
+            return (
+              <MenuItem value={provider} key={provider}>
+                {provider.toUpperCase()}
+              </MenuItem>
+            );
+          })}
         </Select>
         <div>
           <TextField

--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -5,32 +5,32 @@ import { Delete } from '@mui/icons-material';
 import { useAppSelector } from '@renderer/app/store';
 import { selectCodeFileObjects } from '@renderer/features/codeSliceInputSelectors';
 import { TerraformType } from '@renderer/types/terraform';
-import TopologyLibararyItemList from './TopologyLibraryItemList';
+import TopologyLibararyItemList, { Item } from './TopologyLibraryItemList';
 import parseJson from '../state/form/utils/json2JsonSchemaParser';
 
 const defaultList: Item[] = [
   {
-    title: 'defaults-provider',
+    instanceName: 'defaults-provider',
     resourceName: 'provider',
     type: 'provider',
   },
   {
-    title: 'defaults-variable',
+    instanceName: 'defaults-variable',
     resourceName: 'variable',
     type: 'variable',
   },
   {
-    title: 'defaults-output',
+    instanceName: 'defaults-output',
     resourceName: 'output',
     type: 'output',
   },
   {
-    title: 'defaults-terraform',
+    instanceName: 'defaults-terraform',
     resourceName: 'terraform',
     type: 'terraform',
   },
   {
-    title: 'defaults-locals',
+    instanceName: 'defaults-locals',
     resourceName: 'locals',
     type: 'locals',
   },
@@ -61,18 +61,6 @@ function getModuleList(items: Item[]) {
 }
 */
 
-interface Item {
-  path?: string;
-  objectCount?: number;
-  provider?: string;
-  title: string;
-  instanceName?: string;
-  resourceName: string;
-  type: TerraformType;
-  source?: string | any;
-  version?: string;
-  isLocalModule?: boolean;
-}
 let selectedProvider = '';
 
 const TopologyLibrary = () => {
@@ -130,18 +118,17 @@ const TopologyLibrary = () => {
       const instanceName = Object.keys(object[resourceName])[0];
       const keySource = 'source';
       const source = object[resourceName][keySource];
-      const title = type + '-' + resourceName;
-      return { type, resourceName, title, instanceName, source };
+      return { type, resourceName, instanceName, source };
     })
     .forEach((i: Item) => {
       if (i.type === 'module') {
         const isLocal = i.source.charAt(0) === '.';
 
         itemsList.push({
-          title: i.title,
-          source: i.source,
+          instanceName: i.instanceName,
           resourceName: i.resourceName,
           type: i.type,
+          source: i.source,
           isLocalModule: isLocal,
         });
       }
@@ -158,13 +145,11 @@ const TopologyLibrary = () => {
     }
     const items: Item[] = [];
     schemaMap.forEach((schema) => {
-      const schemaProvider = provider;
       const schemaTitle = schema.title;
       const schemaResourceName = schema.title.split('-')[1];
       const schemaType = schema.title.split('-')[0];
       items.push({
-        provider: schemaProvider,
-        title: schemaTitle,
+        instanceName: schemaTitle,
         resourceName: schemaResourceName,
         type: schemaType,
       });
@@ -176,16 +161,14 @@ const TopologyLibrary = () => {
       if (searchByName(searchText, i.resourceName)) {
         if (i.type === 'resource') {
           resourceList.push({
-            provider: i.provider,
-            title: i.title,
+            instanceName: i.instanceName,
             resourceName: i.resourceName,
             type: i.type,
           });
         }
         if (i.type === 'data') {
           datasourceList.push({
-            provider: i.provider,
-            title: i.title,
+            instanceName: i.instanceName,
             resourceName: i.resourceName,
             type: i.type,
           });

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -139,11 +139,11 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
                             dispatch(setSelectedModule(selectedModule));
                           }
                         } else if (
-                          item.resourceName === 'terraform' ||
-                          item.resourceName === 'locals' ||
-                          item.resourceName === 'provider' ||
-                          item.resourceName === 'output' ||
-                          item.resourceName === 'variable'
+                          item.type === 'terraform' ||
+                          item.type === 'locals' ||
+                          item.type === 'provider' ||
+                          item.type === 'output' ||
+                          item.type === 'variable'
                         ) {
                           const newFileName =
                             item.resourceName + '-' + fileObjects.length;
@@ -298,16 +298,11 @@ type TopologyLibararyItemListProps = {
   provider?: string;
 };
 
-interface Item {
-  path?: string;
-  objectCount?: number;
-  provider?: string;
-  title: string;
-  instanceName?: string;
+export interface Item {
+  instanceName: string;
   resourceName: string;
   type: TerraformType;
   source?: string | any;
-  version?: string;
   isLocalModule?: boolean;
 }
 

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -161,9 +161,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
                                   path.sep +
                                   `${newFileName}.tf`,
                                 fileJson: {
-                                  [item.resourceName]: {
-                                    [newInstanceName]: addedObjectJSON,
-                                  },
+                                  [item.resourceName]: addedObjectJSON,
                                 },
                               },
                             ];

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -36,6 +36,7 @@ import {
 } from '@renderer/features/graphSlice';
 import { useWorkspaceUri } from '@renderer/hooks/useWorkspaceUri';
 import { getIcon } from '@renderer/components/topology/icon/IconFactory';
+import { TerraformType } from '@renderer/types/terraform';
 
 const AccordionLayout = styled(Accordion)(({ theme }) => ({
   backgroundColor: theme.palette.object.accordion,
@@ -137,7 +138,13 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
                             dispatch(setSelectedNode(null));
                             dispatch(setSelectedModule(selectedModule));
                           }
-                        } else if (item.type === 'default') {
+                        } else if (
+                          item.resourceName === 'terraform' ||
+                          item.resourceName === 'locals' ||
+                          item.resourceName === 'provider' ||
+                          item.resourceName === 'output' ||
+                          item.resourceName === 'variable'
+                        ) {
                           const newFileName =
                             item.resourceName + '-' + fileObjects.length;
                           let newFileObject;
@@ -298,7 +305,7 @@ interface Item {
   title: string;
   instanceName?: string;
   resourceName: string;
-  type: string;
+  type: TerraformType;
   source?: string | any;
   version?: string;
   isLocalModule?: boolean;

--- a/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
@@ -3,11 +3,11 @@ import parseJson from '../state/form/utils/json2JsonSchemaParser';
 
 export type Provider = 'aws' | 'tls';
 
-export const ProviderList: Provider[] = ['aws', 'tls'];
+export const providerList: Provider[] = ['aws', 'tls'];
 
 const tempResourceMap = new Map();
 const tempDatasourceMap = new Map();
-ProviderList.forEach((provider) => {
+providerList.forEach((provider) => {
   const tempMap = parseJson([provider]);
   const tempResourceList: Item[] = [];
   const tempDatasourceList: Item[] = [];

--- a/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
@@ -1,0 +1,37 @@
+import { Item } from './TopologyLibraryItemList';
+import parseJson from '../state/form/utils/json2JsonSchemaParser';
+
+export type Provider = 'aws' | 'tls';
+
+const providerList: Provider[] = ['aws', 'tls'];
+
+const tempResourceMap = new Map();
+const tempDatasourceMap = new Map();
+providerList.forEach((provider) => {
+  const tempMap = parseJson([provider]);
+  const tempResourceList: Item[] = [];
+  const tempDatasourceList: Item[] = [];
+  tempMap.forEach((schema) => {
+    const schemaTitle = schema.title;
+    const schemaResourceName = schema.title.split('-')[1];
+    const schemaType = schema.title.split('-')[0];
+    if (schemaType === 'resource') {
+      tempResourceList.push({
+        instanceName: schemaTitle,
+        resourceName: schemaResourceName,
+        type: schemaType,
+      });
+    }
+    if (schemaType === 'data') {
+      tempDatasourceList.push({
+        instanceName: schemaTitle,
+        resourceName: schemaResourceName,
+        type: schemaType,
+      });
+    }
+  });
+  tempResourceMap.set(provider, tempResourceList);
+  tempDatasourceMap.set(provider, tempDatasourceList);
+});
+export const resourceMap = tempResourceMap;
+export const datasourceMap = tempDatasourceMap;

--- a/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
@@ -3,11 +3,11 @@ import parseJson from '../state/form/utils/json2JsonSchemaParser';
 
 export type Provider = 'aws' | 'tls';
 
-const providerList: Provider[] = ['aws', 'tls'];
+export const ProviderList: Provider[] = ['aws', 'tls'];
 
 const tempResourceMap = new Map();
 const tempDatasourceMap = new Map();
-providerList.forEach((provider) => {
+ProviderList.forEach((provider) => {
   const tempMap = parseJson([provider]);
   const tempResourceList: Item[] = [];
   const tempDatasourceList: Item[] = [];


### PR DESCRIPTION
[feat] item type 에 TerraformType 적용
default type 없애고 TerraformType 적용

[refact] interface Item 정리
Sidebar 에 items 받아오고 있는 type은 Data 통일하려고 했으나, Module의 source 값을 통해 local module 유무 판단하기 위해 Item type 남기고 필요없는 값들 정리함

[refact] schema 가져오는 부분 파일 분리
parseJson 에서 고정된 리스트로 관리되는 것이라서, useEffact 에서 새롭게 매번 리스트 만드는 과정이 불필요해 보여서 옮김
provider 별로 resourceList, datasourceList 찾을 수 있는 Map 추가


[refact] 주석 정리 및 Provider 선택창 프로바이더 리스트 통해서 생성
Provider 선택항목 프로바이더 리스트 통해서 생성