### PR TITLE
[bugfix] provider-tls 생성 불가 버그 해결,  [refact] item type 에 따른 클릭 액션 정리, [feat] required property 자동 추가, [feat] fuzzysearch 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.0.8",
     "file-loader": "^6.0.0",
+    "fuzzysearch": "^1.0.3",
     "html-webpack-plugin": "^5.3.1",
     "husky": "4.x.x",
     "identity-obj-proxy": "^3.0.0",

--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -8,16 +8,12 @@ import TopologyLibararyItemList, { Item } from './TopologyLibraryItemList';
 import {
   Provider,
   providerList,
+  providerMap,
   resourceMap,
   datasourceMap,
 } from './TopologyLibrarySchema';
 
 const defaultList: Item[] = [
-  {
-    instanceName: 'defaults-provider',
-    resourceName: 'provider',
-    type: 'provider',
-  },
   {
     instanceName: 'defaults-variable',
     resourceName: 'variable',
@@ -65,7 +61,6 @@ function getModuleList(items: Item[]) {
   });
 }
 */
-
 let selectedProvider: Provider = 'tls';
 
 const TopologyLibrary = () => {
@@ -74,6 +69,9 @@ const TopologyLibrary = () => {
   );
   const [searchText, setSearchText] = React.useState('');
   const [debounceSearchText, setDebounceSearchText] = React.useState('');
+  const [providerItems, setProviderItems] = React.useState<Item[]>(
+    providerMap.get('tls').concat(defaultList)
+  );
   const [resourceItems, setResourceItems] = React.useState<Item[]>(
     resourceMap.get('tls')
   );
@@ -98,7 +96,7 @@ const TopologyLibrary = () => {
       } catch (e) {
         console.error('error', e);
       }
-    }, 800);
+    }, 500);
     setTimer(newTimer);
   };
   const deleteSearchText = () => {
@@ -161,9 +159,11 @@ const TopologyLibrary = () => {
     });
 
   React.useEffect(() => {
+    let tempProviderItmes: Item[] = [];
     let tempResourceItmes: Item[] = [];
     let tempDatasourceItmes: Item[] = [];
 
+    tempProviderItmes = providerMap.get(provider);
     tempResourceItmes = resourceMap.get(provider);
     tempDatasourceItmes = datasourceMap.get(provider);
 
@@ -171,7 +171,8 @@ const TopologyLibrary = () => {
 
     selectedProvider = provider;
     setSearchText('');
-
+    setDebounceSearchText('');
+    setProviderItems(tempProviderItmes.concat(defaultList));
     setResourceItems(tempResourceItmes);
     setDatasourceItems(tempDatasourceItmes);
     setIsSearchResultEmpty(false);
@@ -260,17 +261,11 @@ const TopologyLibrary = () => {
           title="로컬 모듈"
         />
         <TopologyLibararyItemList
-          items={defaultList}
+          items={providerItems}
           title="테라폼 디폴트"
           provider={provider}
         />
-        {isSearchResultEmpty ? (
-          <div>
-            <InputLabel>------</InputLabel>
-            <InputLabel>{searchText}</InputLabel>
-            <InputLabel>검색 결과가 없습니다.</InputLabel>
-          </div>
-        ) : (
+        {!isSearchResultEmpty && (
           <>
             {/* 모듈 추후 추가 */}
             {/* <TopologyLibararyItemList items={terraformModuleItems} title="테라폼 모듈" />*/}
@@ -283,6 +278,13 @@ const TopologyLibrary = () => {
               title="테라폼 데이터소스"
             />
           </>
+        )}
+        {isSearchResultEmpty && (
+          <div>
+            <InputLabel>------</InputLabel>
+            <InputLabel>{searchText}</InputLabel>
+            <InputLabel>검색 결과가 없습니다.</InputLabel>
+          </div>
         )}
         {/* 테스트 코드 주석 처리
         <Button onClick={handleModuleListModalOpen} value="test1">

--- a/src/renderer/components/topology/library/TopologyLibrary.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import _ from 'lodash';
+import * as fuzzy from 'fuzzysearch';
 import { Box, MenuItem, InputLabel, Select, TextField } from '@mui/material';
 import { Delete } from '@mui/icons-material';
 import { useAppSelector } from '@renderer/app/store';
@@ -38,11 +39,14 @@ const defaultList: Item[] = [
 
 //fuzzy search? 비슷한 문자열 검색으로 변경 필요
 function searchByName(searchText: string, name: string) {
+  return fuzzy(searchText, name);
+  /*
   if (name.toUpperCase().indexOf(searchText.toUpperCase()) !== -1) {
     return true;
   } else {
     return false;
   }
+  */
 }
 function isLocalModule(item: Item) {
   return item.isLocalModule;

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -150,7 +150,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
     item.required?.forEach((property: string) => {
       const setDefaultValue = (property: string) => {
         switch (item.properties[property]?.type) {
-          case 'beelean': {
+          case 'boolean': {
             return false;
           }
           case 'number': {

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -36,7 +36,7 @@ import {
 } from '@renderer/features/graphSlice';
 import { useWorkspaceUri } from '@renderer/hooks/useWorkspaceUri';
 import { getIcon } from '@renderer/components/topology/icon/IconFactory';
-import { TerraformType } from '@renderer/types/terraform';
+import { TerraformType, getObjectDataType } from '@renderer/types/terraform';
 
 const AccordionLayout = styled(Accordion)(({ theme }) => ({
   backgroundColor: theme.palette.object.accordion,
@@ -86,6 +86,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
   items,
   title,
   provider = '',
+  searchText = '',
 }) => {
   const dispatch = useAppDispatch();
   const fileObjects = useAppSelector(selectCodeFileObjects);
@@ -101,6 +102,118 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
       content: items,
     },
   ];
+  const showModule = (item: Item) => {
+    const name = item.resourceName;
+    const selectedModule = getModuleNodeByName(graphData.nodes, name);
+    if (selectedModule && selectedModule.id) {
+      const selectedData = getPrunedGraph(graphData.nodes, selectedModule.id);
+      dispatch(setSelectedData(selectedData));
+      dispatch(setSelectedNode(null));
+      dispatch(setSelectedModule(selectedModule));
+    }
+  };
+  const setFileName = (item: Item) => {
+    switch (getObjectDataType[item.type]) {
+      case 'THREE_DEPTH_DATA_TYPE': {
+        return item.type + '-' + item.resourceName + '-' + fileObjects.length;
+      }
+      case 'TWO_DEPTH_DATA_TYPE': {
+        return item.type + '-' + fileObjects.length;
+      }
+      case 'ONE_DEPTH_DATA_TYPE': {
+        return item.type + '-' + fileObjects.length;
+      }
+      default:
+        return item.type + '-' + fileObjects.length;
+    }
+  };
+  const setInstanceName = (item: Item) => {
+    if (item.type === 'provider') {
+      return provider;
+    }
+    switch (getObjectDataType[item.type]) {
+      case 'THREE_DEPTH_DATA_TYPE': {
+        return item.type + '-' + item.resourceName + '-' + fileObjects.length;
+      }
+      case 'TWO_DEPTH_DATA_TYPE': {
+        return item.type + '-' + fileObjects.length;
+      }
+      case 'ONE_DEPTH_DATA_TYPE': {
+        return item.type + '-' + fileObjects.length;
+      }
+      default:
+        return item.type + '-' + fileObjects.length;
+    }
+  };
+  const setDefaultValue = (item: Item) => {
+    return addedObjectJSON;
+  };
+  const setFileObject = (item: Item) => {
+    //Set FileName
+    const newFileName = setFileName(item);
+    const newInstanceName = setInstanceName(item);
+    switch (getObjectDataType[item.type]) {
+      case 'THREE_DEPTH_DATA_TYPE': {
+        const newFileObject = [
+          {
+            filePath: `${folderUri}` + path.sep + `${newInstanceName}.tf`,
+            fileJson: {
+              [item.type]: {
+                [item.resourceName]: {
+                  [newInstanceName]: setDefaultValue(item),
+                },
+              },
+            },
+          },
+        ];
+        return newFileObject;
+      }
+      case 'TWO_DEPTH_DATA_TYPE': {
+        const newFileObject = [
+          {
+            filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
+            fileJson: {
+              [item.resourceName]: {
+                [newInstanceName]: setDefaultValue(item),
+              },
+            },
+          },
+        ];
+        return newFileObject;
+      }
+      case 'ONE_DEPTH_DATA_TYPE': {
+        const newFileObject = [
+          {
+            filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
+            fileJson: {
+              [item.type]: setDefaultValue(item),
+            },
+          },
+        ];
+        return newFileObject;
+      }
+      default: {
+        const newFileObject = [
+          {
+            filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
+            fileJson: {
+              [item.type]: setDefaultValue(item),
+            },
+          },
+        ];
+        return newFileObject;
+      }
+    }
+  };
+  const setSidePanelObject = (item: Item) => {
+    const newObject = {
+      type: item.type,
+      resourceName: item.type === 'provider' ? provider : item.resourceName,
+      instanceName: setInstanceName(item),
+      content: setDefaultValue(item),
+    };
+    return newObject;
+  };
 
   return (
     <>
@@ -118,144 +231,25 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
           </AccordionHeader>
           <AccordionDetails sx={{ backgroundColor: 'white', padding: 0 }}>
             <List>
-              {items.map((item, index) => {
+              {accordion.content.map((item, index) => {
                 return (
                   <ListItem disablePadding key={`item-${index}`}>
                     <ListItemButton
                       onClick={async () => {
                         if (item.type === 'module') {
-                          const name = item.resourceName;
-                          const selectedModule = getModuleNodeByName(
-                            graphData.nodes,
-                            name
-                          );
-                          if (selectedModule && selectedModule.id) {
-                            const selectedData = getPrunedGraph(
-                              graphData.nodes,
-                              selectedModule.id
-                            );
-                            dispatch(setSelectedData(selectedData));
-                            dispatch(setSelectedNode(null));
-                            dispatch(setSelectedModule(selectedModule));
-                          }
-                        } else if (
-                          item.type === 'terraform' ||
-                          item.type === 'locals' ||
-                          item.type === 'provider' ||
-                          item.type === 'output' ||
-                          item.type === 'variable'
-                        ) {
-                          const newFileName =
-                            item.resourceName + '-' + fileObjects.length;
-                          let newFileObject;
-                          let newInstanceName = newFileName;
-                          if (
-                            item.resourceName === 'terraform' ||
-                            item.resourceName === 'locals'
-                          ) {
-                            newInstanceName = item.resourceName;
-                            newFileObject = [
-                              {
-                                filePath:
-                                  `${folderUri}` +
-                                  path.sep +
-                                  `${newFileName}.tf`,
-                                fileJson: {
-                                  [item.resourceName]: addedObjectJSON,
-                                },
-                              },
-                            ];
-                          } else if (item.resourceName === 'provider') {
-                            newInstanceName = provider;
-                            newFileObject = [
-                              {
-                                filePath:
-                                  `${folderUri}` +
-                                  path.sep +
-                                  `${newFileName}.tf`,
-                                fileJson: {
-                                  [item.resourceName]: {
-                                    [newInstanceName]: addedObjectJSON,
-                                  },
-                                },
-                              },
-                            ];
-                          } else {
-                            newFileObject = [
-                              {
-                                filePath:
-                                  `${folderUri}` +
-                                  path.sep +
-                                  `${newFileName}.tf`,
-                                fileJson: {
-                                  [item.resourceName]: {
-                                    [newInstanceName]: addedObjectJSON,
-                                  },
-                                },
-                              },
-                            ];
-                          }
-                          const newFileObjects =
-                            fileObjects.concat(newFileObject);
-                          dispatch(setFileObjects(newFileObjects));
-                          const object = {
-                            type: item.resourceName,
-                            resourceName: '',
-                            instanceName: newInstanceName,
-                            content: addedObjectJSON,
-                          };
-                          dispatch(setSelectedObjectInfo(object));
-                          dispatch(setSidePanel(true));
-                          // TemporaryDataPath에 변경사항 저장 (terraform plan 용도)
-                          const result = await exportProject({
-                            objects: newFileObjects,
-                            workspaceUid,
-                            isAllSave: false,
-                            typeMap: mapObjectCollection,
-                            deleteTypeInfo: {
-                              isFileDeleted: false,
-                              filePath: '',
-                            },
-                          });
-                          if (result.status === WorkspaceStatusType.SUCCESS) {
-                            dispatch(setFileDirty(true));
-                            dispatch(watchGraphData(workspaceUid));
-                          }
+                          showModule(item);
                         } else {
-                          const { type } = item;
-                          const newInstanceName =
-                            item.type +
-                            '-' +
-                            item.resourceName +
-                            '-' +
-                            fileObjects.length;
-                          const newFileObject = [
-                            {
-                              filePath:
-                                `${folderUri}` +
-                                path.sep +
-                                `${newInstanceName}.tf`,
-                              fileJson: {
-                                [type]: {
-                                  [item.resourceName]: {
-                                    [newInstanceName]: addedObjectJSON,
-                                  },
-                                },
-                              },
-                            },
-                          ];
+                          //Set FileObject
+                          const newFileObject = setFileObject(item);
+                          //Update FileObjects
                           const newFileObjects =
                             fileObjects.concat(newFileObject);
                           dispatch(setFileObjects(newFileObjects));
-                          const object = {
-                            type: item.type,
-                            resourceName: item.resourceName,
-                            instanceName: newInstanceName,
-                            content: addedObjectJSON,
-                          };
+                          //Set SidePanel
+                          const object = setSidePanelObject(item);
                           dispatch(setSelectedObjectInfo(object));
                           dispatch(setSidePanel(true));
-                          // TemporaryDataPath에 변경사항 저장 (terraform plan 용도)
+                          //Export to TemporaryDataPath (terraform plan 용도)
                           const result = await exportProject({
                             objects: newFileObjects,
                             workspaceUid,
@@ -288,12 +282,13 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
     </>
   );
 };
-TopologyLibararyItemList.defaultProps = { provider: '' };
+TopologyLibararyItemList.defaultProps = { provider: '', searchText: '' };
 
 type TopologyLibararyItemListProps = {
   items: Item[];
   title: string;
   provider?: string;
+  searchText?: string;
 };
 
 export interface Item {
@@ -302,6 +297,7 @@ export interface Item {
   type: TerraformType;
   source?: string | any;
   isLocalModule?: boolean;
+  properties?: any;
 }
 
 export default TopologyLibararyItemList;

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import _ from 'lodash';
 import path from 'path';
 import { WorkspaceStatusType } from '@main/workspaces/common/workspace';
 import {
@@ -93,7 +94,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
   const workspaceUid = useAppSelector(selectWorkspaceUid);
   const mapObjectCollection = useAppSelector(selectMapObjectTypeCollection);
   const folderUri = useWorkspaceUri(workspaceUid);
-  const addedObjectJSON = {}; //temp
+  const addedObjectJSON: any = {}; //temp
   const graphData = useAppSelector(selectGraphData);
   const accordions = [
     {
@@ -145,7 +146,36 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
         return item.type + '-' + fileObjects.length;
     }
   };
-  const setDefaultValue = (item: Item) => {
+  const setDefaultValues = (item: Item) => {
+    item.required?.forEach((property: string) => {
+      const setDefaultValue = (property: string) => {
+        switch (item.properties[property]?.type) {
+          case 'beelean': {
+            return false;
+          }
+          case 'number': {
+            return 0;
+          }
+          case 'string': {
+            return '';
+          }
+          case 'object': {
+            return {};
+          }
+          case 'array': {
+            return [];
+          }
+          default:
+            return '';
+        }
+      };
+      _.merge(addedObjectJSON, { [property]: setDefaultValue(property) });
+    });
+    /*
+    item.properties.forEach((property: any) => {
+      Object.keys(property).includes('required');
+    });
+    */
     return addedObjectJSON;
   };
   const setFileObject = (item: Item) => {
@@ -160,7 +190,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
             fileJson: {
               [item.type]: {
                 [item.resourceName]: {
-                  [newInstanceName]: setDefaultValue(item),
+                  [newInstanceName]: setDefaultValues(item),
                 },
               },
             },
@@ -174,7 +204,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
             filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
             fileJson: {
               [item.resourceName]: {
-                [newInstanceName]: setDefaultValue(item),
+                [newInstanceName]: setDefaultValues(item),
               },
             },
           },
@@ -186,7 +216,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
           {
             filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
             fileJson: {
-              [item.type]: setDefaultValue(item),
+              [item.type]: setDefaultValues(item),
             },
           },
         ];
@@ -197,7 +227,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
           {
             filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
             fileJson: {
-              [item.type]: setDefaultValue(item),
+              [item.type]: setDefaultValues(item),
             },
           },
         ];
@@ -210,7 +240,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
       type: item.type,
       resourceName: item.type === 'provider' ? provider : item.resourceName,
       instanceName: setInstanceName(item),
-      content: setDefaultValue(item),
+      content: setDefaultValues(item),
     };
     return newObject;
   };
@@ -270,7 +300,11 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
                       <ListItemIcon sx={{ minWidth: 36 }}>
                         {getIcon(item.resourceName, 24)}
                       </ListItemIcon>
-                      <ListItemName>{item.resourceName}</ListItemName>
+                      <ListItemName>
+                        {item.type === 'provider'
+                          ? 'provider(' + provider + ')'
+                          : item.resourceName}
+                      </ListItemName>
                     </ListItemButton>
                   </ListItem>
                 );
@@ -298,6 +332,7 @@ export interface Item {
   source?: string | any;
   isLocalModule?: boolean;
   properties?: any;
+  required?: any;
 }
 
 export default TopologyLibararyItemList;

--- a/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
@@ -5,10 +5,12 @@ export type Provider = 'aws' | 'tls';
 
 export const providerList: Provider[] = ['aws', 'tls'];
 
+const tempProviderMap = new Map();
 const tempResourceMap = new Map();
 const tempDatasourceMap = new Map();
 providerList.forEach((provider) => {
   const tempMap = parseJson([provider]);
+  const tempProviderList: Item[] = [];
   const tempResourceList: Item[] = [];
   const tempDatasourceList: Item[] = [];
   tempMap.forEach((schema) => {
@@ -16,12 +18,23 @@ providerList.forEach((provider) => {
     const schemaResourceName = schema.title.split('-')[1];
     const schemaType = schema.title.split('-')[0];
     const schemaProperties = schema.properties;
+    const schemaRequired = schema.required;
+    if (schemaType === 'provider') {
+      tempProviderList.push({
+        instanceName: schemaTitle,
+        resourceName: schemaResourceName,
+        type: schemaType,
+        properties: schemaProperties,
+        required: schemaRequired,
+      });
+    }
     if (schemaType === 'resource') {
       tempResourceList.push({
         instanceName: schemaTitle,
         resourceName: schemaResourceName,
         type: schemaType,
         properties: schemaProperties,
+        required: schemaRequired,
       });
     }
     if (schemaType === 'data') {
@@ -30,11 +43,14 @@ providerList.forEach((provider) => {
         resourceName: schemaResourceName,
         type: schemaType,
         properties: schemaProperties,
+        required: schemaRequired,
       });
     }
   });
+  tempProviderMap.set(provider, tempProviderList);
   tempResourceMap.set(provider, tempResourceList);
   tempDatasourceMap.set(provider, tempDatasourceList);
 });
+export const providerMap = tempProviderMap;
 export const resourceMap = tempResourceMap;
 export const datasourceMap = tempDatasourceMap;

--- a/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
+++ b/src/renderer/components/topology/library/TopologyLibrarySchema.tsx
@@ -15,11 +15,13 @@ providerList.forEach((provider) => {
     const schemaTitle = schema.title;
     const schemaResourceName = schema.title.split('-')[1];
     const schemaType = schema.title.split('-')[0];
+    const schemaProperties = schema.properties;
     if (schemaType === 'resource') {
       tempResourceList.push({
         instanceName: schemaTitle,
         resourceName: schemaResourceName,
         type: schemaType,
+        properties: schemaProperties,
       });
     }
     if (schemaType === 'data') {
@@ -27,6 +29,7 @@ providerList.forEach((provider) => {
         instanceName: schemaTitle,
         resourceName: schemaResourceName,
         type: schemaType,
+        properties: schemaProperties,
       });
     }
   });

--- a/src/renderer/components/topology/state/form/AddFieldSection.tsx
+++ b/src/renderer/components/topology/state/form/AddFieldSection.tsx
@@ -71,6 +71,10 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
         ? Object.keys(sourceSchema.properties as JSONSchema7Definition)
         : [];
 
+    if (_.isEmpty(schema.properties as JSONSchema7Definition)) {
+      return [];
+    }
+
     return _.xor(
       _.intersection(
         selectedSchema,


### PR DESCRIPTION
[bugfix] provider-tls 생성 불가 버그 해결 - schema.properties 가 빈 객체 일때 예외 처리
[현상]
 tls provider 생성하면 에러화면 나옴

[원인]
확인 결과 Object 는 생성은 되지만 sidepanel 열리는데서 문제가 생김
tls provider 처럼 schema.properties 가 {} 빈 객체일때 생기는 문제

[해결]
빈 객체일때 예외 처리


[refact] item 에 schema 포함 하도록 변경, item type 에 따른 클릭 액션 정리

TopologyLibrarySchema.tsx
필수값 판별을 위해서 item 에 schemaProperties 포함하도록 변경

TopologyLibraryItemList.tsx
type 별로 하나하나 액션 작성 했던 것을
하나의 액션에 type 별로 다른 object 를 포함하게 하도록 변경


[feat] required property 자동 추가
schema 에서 required 값 확인 후 타입에 맞추어서 추가함


 [feat] fuzzysearch 추가