### PR TITLE
[feat] Color Key 툴바 버튼 구현

### DIFF
--- a/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
+++ b/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
@@ -27,18 +27,19 @@ import {
   ZoomInButton,
   ZoomOutButton,
   TerraformPlanButton,
+  ColorKeyButton,
 } from './button';
 import ViewBreadcrumbs from './breadcrumb/ViewBreadcrumb';
 import { ModuleListModal } from '../modal';
+import ColorKeyPopover from './popover/ColorKeyPopover';
 
 export const TOPOLOGY_TOOLBAR_HEIGHT = 50;
 
 const TopologyToolbar = (props: TopologyToolbarProps) => {
   const { handlers } = props;
   const [openModuleListModal, setOpenModuleListModal] = React.useState(false);
-
-  const handleModuleListModalOpen = () => setOpenModuleListModal(true);
-  const handleModuleListModalClose = () => setOpenModuleListModal(false);
+  const [openColorKeyPopover, setOpenColorKeyPopover] =
+    React.useState<HTMLButtonElement | null>(null);
 
   const fileObjects = useAppSelector(selectCodeFileObjects);
   const workspaceUid = useAppSelector(selectWorkspaceUid);
@@ -47,6 +48,9 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
   const workspaceName = useWorkspaceName(workspaceUid);
 
   const dispatch = useAppDispatch();
+
+  const handleModuleListModalOpen = () => setOpenModuleListModal(true);
+  const handleModuleListModalClose = () => setOpenModuleListModal(false);
 
   const handleSaveButtonClick = async () => {
     const result = await exportProject({
@@ -70,6 +74,15 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
   const handleTerraformApplyButton = async () => {
     dispatch(fetchTerraformApplyDataByWorkspaceId(workspaceUid));
     dispatch(setLoadingModal(true));
+  };
+
+  const handleColorKeyButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    const open = Boolean(openColorKeyPopover);
+    open
+      ? setOpenColorKeyPopover(null)
+      : setOpenColorKeyPopover(event.currentTarget);
   };
 
   return (
@@ -116,6 +129,20 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
         <ZoomInButton onClick={handlers.handleZoomIn} />
         <ZoomOutButton onClick={handlers.handleZoomOut} />
         <FitScreenButton onClick={handlers.handleZoomToFit} />
+        <Divider
+          orientation="vertical"
+          variant="middle"
+          flexItem
+          sx={{ mx: 1 }}
+        />
+        <ColorKeyButton
+          clicked={Boolean(openColorKeyPopover)}
+          onClick={handleColorKeyButtonClick}
+        />
+        <ColorKeyPopover
+          anchorEl={openColorKeyPopover}
+          setAnchorEl={setOpenColorKeyPopover}
+        />
       </Box>
     </Toolbar>
   );

--- a/src/renderer/components/topology/toolbar/button/ColorKeyButton.tsx
+++ b/src/renderer/components/topology/toolbar/button/ColorKeyButton.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Tooltip } from '@mui/material';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import ColorLensOutlinedIcon from '@mui/icons-material/ColorLensOutlined';
+
+const ColorKeyButton = (props: ColorKeyButtonProps) => {
+  const { label = 'Color Key', onClick, className, clicked, ...rest } = props;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (typeof onClick === 'function') {
+      onClick(event);
+    }
+  };
+
+  return (
+    <Tooltip title={label}>
+      <span>
+        <IconButton
+          aria-label={label}
+          className={className}
+          onClick={handleClick}
+          {...rest}
+          sx={{ p: '4px' }}
+        >
+          <ColorLensOutlinedIcon
+            fontSize="small"
+            sx={{
+              color: clicked ? '#0066CC' : '#5b6c7f',
+              backgroundColor: clicked ? '#D6E4FC' : 'transparent',
+              p: '4px',
+            }}
+          />
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+};
+
+interface Props {
+  className?: string;
+  label?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  clicked: boolean;
+}
+
+export type ColorKeyButtonProps = Props & IconButtonProps;
+
+export default ColorKeyButton;

--- a/src/renderer/components/topology/toolbar/button/index.ts
+++ b/src/renderer/components/topology/toolbar/button/index.ts
@@ -1,3 +1,4 @@
+export { default as ColorKeyButton } from './ColorKeyButton';
 export { default as FitScreenButton } from './FitScreenButton';
 export { default as SaveButton } from './SaveButton';
 export { default as SelectModuleButton } from './SelectModuleButton';

--- a/src/renderer/components/topology/toolbar/popover/ColorKeyPopover.tsx
+++ b/src/renderer/components/topology/toolbar/popover/ColorKeyPopover.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import {
+  Divider,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Popover,
+  Typography,
+} from '@mui/material';
+
+const ColorKeyPopover = (props: ColorKeyPopoverProps) => {
+  const { anchorEl, setAnchorEl } = props;
+
+  const open = Boolean(anchorEl);
+
+  const colorList = [
+    {
+      name: '프로바이더',
+      color: 'rgb(255, 87, 134)',
+    },
+    {
+      name: '리소스',
+      color: 'rgb(0, 183, 189)',
+    },
+    {
+      name: '데이터소스',
+      color: 'rgb(144, 157, 255)',
+    },
+    {
+      name: '모듈',
+      color: 'rgb(255, 173, 48)',
+    },
+  ];
+
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={() => setAnchorEl(null)}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+    >
+      <Paper
+        sx={{
+          width: 160,
+          height: 160,
+          p: 2,
+        }}
+      >
+        <Typography variant="h5" noWrap component="div" sx={{ mb: 1 }}>
+          Color Key
+        </Typography>
+        <List disablePadding>
+          {colorList.map((item) => {
+            return (
+              <ListItem key={item.name} disablePadding>
+                <ListItemIcon sx={{ minWidth: 36 }}>
+                  <Divider
+                    orientation="vertical"
+                    flexItem
+                    sx={{ borderWidth: 10, borderColor: item.color }}
+                  />
+                </ListItemIcon>
+                <ListItemText primary={item.name} />
+              </ListItem>
+            );
+          })}
+        </List>
+      </Paper>
+    </Popover>
+  );
+};
+
+interface ColorKeyPopoverProps {
+  anchorEl: HTMLButtonElement | null;
+  setAnchorEl: any;
+}
+
+export default ColorKeyPopover;


### PR DESCRIPTION
Color Key 툴바 버튼 클릭 시, 노드별 색상 정보를 나타내는 팝오버 출현

![image](https://user-images.githubusercontent.com/29051383/147546966-b9a49604-813f-4c3f-b9e1-3648f66fadb9.png)
