### PR TITLE
[feat] 검색 툴바 추가

### DIFF
--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -30,6 +30,7 @@ import { getModuleNodeByName, getPrunedGraph } from '@renderer/utils/graph';
 import { selectGraphData } from '@renderer/features/graphSliceInputSelectors';
 import { selectWorkspaceUid } from '@renderer/features/commonSliceInputSelectors';
 import {
+  setFilterNodes,
   setSelectedData,
   setSelectedModule,
   setSelectedNode,
@@ -111,6 +112,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
       dispatch(setSelectedData(selectedData));
       dispatch(setSelectedNode(null));
       dispatch(setSelectedModule(selectedModule));
+      dispatch(setFilterNodes(null));
     }
   };
   const setFileName = (item: Item) => {

--- a/src/renderer/components/topology/modal/ModuleListModal.tsx
+++ b/src/renderer/components/topology/modal/ModuleListModal.tsx
@@ -20,6 +20,7 @@ import { selectGraphData } from '@renderer/features/graphSliceInputSelectors';
 import { getModuleData, getPrunedGraph } from '@renderer/utils/graph';
 import { ModuleData } from '@renderer/types/graph';
 import {
+  setFilterNodes,
   setSelectedData,
   setSelectedModule,
   setSelectedNode,
@@ -78,6 +79,7 @@ const ModuleListModal = (props: ModuleListModalProps) => {
       dispatch(setSelectedModule(nodesById(graphData.nodes)[item.id]));
     }
     dispatch(setSelectedNode(null));
+    dispatch(setFilterNodes(null));
     onClose();
   };
 

--- a/src/renderer/components/topology/object/TopologyObjectTableNameCell.tsx
+++ b/src/renderer/components/topology/object/TopologyObjectTableNameCell.tsx
@@ -15,7 +15,7 @@ import { useAppDispatch, useAppSelector } from '@renderer/app/store';
 import { selectSelectedData } from '@renderer/features/graphSliceInputSelectors';
 import { setSelectedObjectInfo } from '@renderer/features/codeSlice';
 import { setSidePanel } from '@renderer/features/uiSlice';
-import { setSelectedNode } from '@renderer/features/graphSlice';
+import { setFilterNodes, setSelectedNode } from '@renderer/features/graphSlice';
 import { NodeData } from '@renderer/types/graph';
 
 const filterObj = (
@@ -113,6 +113,7 @@ const TopologyObjectTableNameCell = (props: NameCellProps) => {
       );
     });
     node ? dispatch(setSelectedNode(node)) : dispatch(setSelectedNode(null));
+    dispatch(setFilterNodes(null));
 
     // 폼 에디터 연동
     const selectedObj = filterObj(objResult, type, resourceName, instanceName);

--- a/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
+++ b/src/renderer/components/topology/toolbar/TopologyToolbar.tsx
@@ -32,6 +32,7 @@ import {
 import ViewBreadcrumbs from './breadcrumb/ViewBreadcrumb';
 import { ModuleListModal } from '../modal';
 import ColorKeyPopover from './popover/ColorKeyPopover';
+import SearchTextfield from './textfield/SearchTextfield';
 
 export const TOPOLOGY_TOOLBAR_HEIGHT = 50;
 
@@ -143,6 +144,13 @@ const TopologyToolbar = (props: TopologyToolbarProps) => {
           anchorEl={openColorKeyPopover}
           setAnchorEl={setOpenColorKeyPopover}
         />
+        <Divider
+          orientation="vertical"
+          variant="middle"
+          flexItem
+          sx={{ mx: 1 }}
+        />
+        <SearchTextfield />
       </Box>
     </Toolbar>
   );

--- a/src/renderer/components/topology/toolbar/breadcrumb/ViewBreadcrumb.tsx
+++ b/src/renderer/components/topology/toolbar/breadcrumb/ViewBreadcrumb.tsx
@@ -8,6 +8,7 @@ import {
   selectSelectedModule,
 } from '@renderer/features/graphSliceInputSelectors';
 import {
+  setFilterNodes,
   setSelectedData,
   setSelectedModule,
   setSelectedNode,
@@ -69,6 +70,7 @@ const ViewBreadcrumbs = (props: ViewBreadcrumbProps) => {
       dispatch(setSelectedData(selectedData));
       dispatch(setSelectedNode(null));
       dispatch(setSelectedModule(selectedModule));
+      dispatch(setFilterNodes(null));
     }
   };
 
@@ -77,6 +79,7 @@ const ViewBreadcrumbs = (props: ViewBreadcrumbProps) => {
     dispatch(setSelectedData(graphData));
     dispatch(setSelectedNode(null));
     dispatch(setSelectedModule(null));
+    dispatch(setFilterNodes(null));
   };
 
   const root = !!workspaceName

--- a/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
+++ b/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
@@ -39,10 +39,17 @@ const SearchTextfield = () => {
       dispatch(setFilterNodes(null));
     } else {
       const nodes = (graphData.nodes as NodeData[]).filter((node) => {
-        return (
-          node.resourceName?.includes(newValue) ||
-          node.instanceName.includes(newValue)
-        );
+        if (node.type !== 'resource' && node.type !== 'data') {
+          return (
+            node.type?.includes(newValue) ||
+            node.instanceName.includes(newValue)
+          );
+        } else {
+          return (
+            node.resourceName?.includes(newValue) ||
+            node.instanceName.includes(newValue)
+          );
+        }
       });
       nodes ? dispatch(setFilterNodes(nodes)) : dispatch(setFilterNodes(null));
       dispatch(setSelectedNode(null));

--- a/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
+++ b/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
@@ -41,8 +41,7 @@ const SearchTextfield = () => {
       const nodes = (graphData.nodes as NodeData[]).filter((node) => {
         if (node.type !== 'resource' && node.type !== 'data') {
           return (
-            node.type?.includes(newValue) ||
-            node.instanceName.includes(newValue)
+            node.type.includes(newValue) || node.instanceName.includes(newValue)
           );
         } else {
           return (

--- a/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
+++ b/src/renderer/components/topology/toolbar/textfield/SearchTextfield.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {
+  FormControl,
+  IconButton,
+  InputAdornment,
+  OutlinedInput,
+  styled,
+} from '@mui/material';
+import { SearchOutlined } from '@mui/icons-material';
+import { useAppDispatch, useAppSelector } from '@renderer/app/store';
+import { selectSelectedData } from '@renderer/features/graphSliceInputSelectors';
+import { NodeData } from '@renderer/types/graph';
+import { setFilterNodes, setSelectedNode } from '@renderer/features/graphSlice';
+
+const StyledTextField = styled(OutlinedInput)(({ theme }) => ({
+  '&.MuiOutlinedInput-root': {
+    '&.Mui-focused fieldset': {
+      borderColor: theme.palette.toolbar.butonClicked,
+    },
+  },
+}));
+
+const SearchIcon = styled(SearchOutlined)(({ theme }) => ({
+  color: theme.palette.toolbar.button,
+}));
+
+const SearchTextfield = () => {
+  const [value, setValue] = React.useState('');
+
+  const dispatch = useAppDispatch();
+  const graphData = useAppSelector(selectSelectedData);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setValue(newValue);
+
+    // 그래프 연동
+    if (newValue === '') {
+      dispatch(setFilterNodes(null));
+    } else {
+      const nodes = (graphData.nodes as NodeData[]).filter((node) => {
+        return (
+          node.resourceName?.includes(newValue) ||
+          node.instanceName.includes(newValue)
+        );
+      });
+      nodes ? dispatch(setFilterNodes(nodes)) : dispatch(setFilterNodes(null));
+      dispatch(setSelectedNode(null));
+    }
+  };
+
+  return (
+    <FormControl sx={{ ml: 1, width: 200, minHeight: 36, maxHeight: 36 }}>
+      <StyledTextField
+        type="text"
+        placeholder="리소스 검색"
+        value={value}
+        onChange={handleChange}
+        inputProps={{
+          style: {
+            padding: '6px 16px',
+          },
+        }}
+        endAdornment={
+          <InputAdornment position="end">
+            <IconButton edge="end" disabled>
+              <SearchIcon />
+            </IconButton>
+          </InputAdornment>
+        }
+      />
+    </FormControl>
+  );
+};
+
+export default SearchTextfield;

--- a/src/renderer/features/graphSlice.ts
+++ b/src/renderer/features/graphSlice.ts
@@ -16,6 +16,7 @@ interface GraphState {
   selectedData: GraphData; // 선택한 모듈 하위 그래프 데이터
   selectedNode: NodeData | null; // 선택한 노드
   selectedModule: NodeData | null; // 선택한 모듈 모드
+  filterNodes: NodeData[] | null; // 검색 시 필터링된 노드
   errorMsg: string | null; // 에러 메시지
 }
 
@@ -30,6 +31,7 @@ const initialState: GraphState = {
   selectedData: { nodes: [], links: [] },
   selectedNode: null,
   selectedModule: null,
+  filterNodes: null,
   errorMsg: null,
 };
 
@@ -111,6 +113,9 @@ const graphSlice = createSlice({
     setSelectedModule: (state, { payload }) => {
       state.selectedModule = payload;
     },
+    setFilterNodes: (state, { payload }) => {
+      state.filterNodes = payload;
+    },
   },
   extraReducers: (builder) => {
     // watchGraphData: 데이터 가져오기 및 에러 상황 처리
@@ -172,6 +177,7 @@ export const {
   setSelectedData,
   setSelectedNode,
   setSelectedModule,
+  setFilterNodes,
 } = graphSlice.actions;
 
 export default graphSlice.reducer;

--- a/src/renderer/features/graphSliceInputSelectors.ts
+++ b/src/renderer/features/graphSliceInputSelectors.ts
@@ -12,7 +12,7 @@ export const selectSelectedNode = (state: RootState): NodeData | null =>
   state.graph.selectedNode;
 export const selectSelectedModule = (state: RootState): NodeData | null =>
   state.graph.selectedModule;
+export const selectFilterNodes = (state: RootState): NodeData[] | null =>
+  state.graph.filterNodes;
 export const selectErrorMsg = (state: RootState): string | null =>
   state.graph.errorMsg;
-export const selectLoadingMsg = (state: RootState): string | null =>
-  state.graph.loadingMsg;

--- a/src/renderer/hooks/useGraphProps.ts
+++ b/src/renderer/hooks/useGraphProps.ts
@@ -17,11 +17,13 @@ import {
 import { DrawingKind } from '@renderer/utils/graph/draw';
 import { useAppDispatch, useAppSelector } from '@renderer/app/store';
 import {
+  selectFilterNodes,
   selectSelectedData,
   selectSelectedModule,
   selectSelectedNode,
 } from '@renderer/features/graphSliceInputSelectors';
 import {
+  setFilterNodes,
   setSelectedData,
   setSelectedModule,
   setSelectedNode,
@@ -50,6 +52,7 @@ export const useGraphProps = () => {
   const graphData = useAppSelector(selectSelectedData);
   const selectedNode = useAppSelector(selectSelectedNode);
   const selectedModule = useAppSelector(selectSelectedModule);
+  const filterNodes = useAppSelector(selectFilterNodes);
 
   const dispatch = useAppDispatch();
 
@@ -70,6 +73,9 @@ export const useGraphProps = () => {
     if (hoverNode) {
       drawingKind = hasNode(highlightNodes, node) ? 'hover' : 'blur';
     }
+    if (filterNodes) {
+      drawingKind = hasNode(filterNodes, node) ? 'hover' : 'blur';
+    }
     if (node.id === selectedNode?.id) {
       drawingKind = 'selected';
     }
@@ -80,6 +86,9 @@ export const useGraphProps = () => {
   };
 
   const linkVisibility = (link: LinkObject) => {
+    if (filterNodes) {
+      return false;
+    }
     if (!configRef.current.hoverNode) {
       return true;
     }
@@ -125,6 +134,7 @@ export const useGraphProps = () => {
         dispatch(setSelectedData(newData));
         dispatch(setSelectedModule(node));
         dispatch(setSelectedNode(null));
+        dispatch(setSidePanel(true));
       }
     }
   };
@@ -146,7 +156,9 @@ export const useGraphProps = () => {
       const codeInfo: any = getCodeInfo(fileObjects, node);
       if (codeInfo) {
         dispatch(setSelectedObjectInfo(codeInfo));
-        dispatch(setSidePanel(true));
+        if (node.type !== 'module') {
+          dispatch(setSidePanel(true));
+        }
       } else {
         dispatch(setSidePanel(false));
       }
@@ -155,6 +167,7 @@ export const useGraphProps = () => {
       dispatch(setSelectedNode(null));
       dispatch(setSidePanel(false));
     }
+    dispatch(setFilterNodes(null));
   };
 
   const handleNodeHover = (
@@ -182,6 +195,7 @@ export const useGraphProps = () => {
     const node = obj as NodeData;
     configRef.current.dragNode = node;
     dispatch(setSelectedNode(null));
+    dispatch(setFilterNodes(null));
   };
 
   const handleNodeDragEnd = (

--- a/src/renderer/theme/index.js
+++ b/src/renderer/theme/index.js
@@ -16,6 +16,7 @@ const theme = createTheme({
     },
     toolbar: {
       button: '#5b6c7f',
+      butonClicked: '#0066CC',
     },
     object: {
       accordion: '#F3F6FA',

--- a/src/renderer/theme/theme.d.ts
+++ b/src/renderer/theme/theme.d.ts
@@ -4,6 +4,7 @@ declare module '@mui/material/styles' {
   export interface Palette {
     toolbar: {
       button: string;
+      butonClicked: string;
     };
     object: {
       accordion: string;
@@ -16,6 +17,7 @@ declare module '@mui/material/styles' {
   export interface PaletteOptions {
     toolbar: {
       button: string;
+      buttonClicked: string;
     };
     object: {
       accordion: string;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29051383/147634081-1abb3b25-b726-417e-a1fc-789e3e43d6cf.png)

검색란에 키 입력 시, 해당되는 노드가 하이라이팅 되도록 구현 (검색에 대한 기획이 없어, 임의 구현)
- 리소스일 경우: `리소스 이름`이나 `인스턴스 이름`으로 검색 가능
- 리소스가 아닌 경우: `타입`이나 `인스턴스 이름`으로 검색 가능
- 필터링된 노드 관리를 위한 global state 추가 및 필터링에 대한 그래프 렌더링 로직 추가 구현