### PR TITLE
[feat] 스키마 없을때 스키마 추가 비활성화, [feat] 항목 추가 항상 열림 및 크기 조절,  [bugfix] 리소스 타입 에러 수정,  [bugfix] 삭제 했던 키 다시 나타나는 현상 수정, [bugfix] schema 사라지는 버그 수정

### DIFF
--- a/src/renderer/components/topology/TopologySidePanel.tsx
+++ b/src/renderer/components/topology/TopologySidePanel.tsx
@@ -74,6 +74,10 @@ const TopologySidePanel = () => {
           formData={formData}
           uiSchema={customUISchema}
           id={id}
+          type={type}
+          resourceName={resourceName}
+          instanceName={instanceName}
+          sourceSchema={sourceSchema}
         />
       </Drawer>
     </>

--- a/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
+++ b/src/renderer/components/topology/library/TopologyLibraryItemList.tsx
@@ -205,7 +205,7 @@ const TopologyLibararyItemList: React.FC<TopologyLibararyItemListProps> = ({
           {
             filePath: `${folderUri}` + path.sep + `${newFileName}.tf`,
             fileJson: {
-              [item.resourceName]: {
+              [item.type]: {
                 [newInstanceName]: setDefaultValues(item),
               },
             },

--- a/src/renderer/components/topology/state/StateTabs.tsx
+++ b/src/renderer/components/topology/state/StateTabs.tsx
@@ -43,6 +43,7 @@ function a11yProps(index: number) {
 
 const FormTabs = (props: FormTabsProps) => {
   const { schema, formData, uiSchema, id } = props;
+  const { type, resourceName, instanceName, sourceSchema } = props;
   const [value, setValue] = React.useState(0);
 
   const handleChange = (event: any, newValue: number) => {
@@ -67,6 +68,10 @@ const FormTabs = (props: FormTabsProps) => {
           formData={formData}
           uiSchema={uiSchema}
           id={id}
+          type={type}
+          resourceName={resourceName}
+          instanceName={instanceName}
+          sourceSchema={sourceSchema}
         />
       </TabPanel>
       {/* <TabPanel value={value} index={1}>
@@ -84,6 +89,10 @@ type FormTabsProps = {
   formData: any;
   uiSchema: any;
   id: string;
+  type: any;
+  resourceName: any;
+  instanceName: any;
+  sourceSchema: any;
 };
 
 export default FormTabs;

--- a/src/renderer/components/topology/state/form/AddFieldSection.tsx
+++ b/src/renderer/components/topology/state/form/AddFieldSection.tsx
@@ -98,7 +98,7 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
   }, [formData]);
   return (
     <div>
-      <Accordion>
+      <Accordion defaultExpanded={true}>
         <AccordionSummary expandIcon={<ArrowDropDown />}>
           입력 필드 추가
         </AccordionSummary>

--- a/src/renderer/components/topology/state/form/AddFieldSection.tsx
+++ b/src/renderer/components/topology/state/form/AddFieldSection.tsx
@@ -111,7 +111,9 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
             }}
           >
             <FormControl fullWidth>
-              <InputLabel id="schema-label">스키마</InputLabel>
+              <InputLabel id="schema-label">
+                {currentSchemaList.length === 0 ? '스키마 없음' : '스키마'}
+              </InputLabel>
               <Select
                 labelId="schema-label"
                 id={getId(type, resourceName, instanceName)}
@@ -121,6 +123,7 @@ const AddFieldSection = (props: AddFieldSectionProps) => {
                 onChange={(e) => {
                   setAdditionalSchema(e.target.value);
                 }}
+                disabled={currentSchemaList.length === 0}
               >
                 {currentSchemaList &&
                   currentSchemaList.map((cur) => (

--- a/src/renderer/components/topology/state/form/Editor.tsx
+++ b/src/renderer/components/topology/state/form/Editor.tsx
@@ -33,7 +33,7 @@ const EditorTab = (props: EditorTabProps) => {
       <div
         style={{
           paddingTop: '12px',
-          height: '663px',
+          height: '530px',
           overflowY: 'auto',
           overflowX: 'hidden',
           marginBottom: '5px',

--- a/src/renderer/components/topology/state/form/Editor.tsx
+++ b/src/renderer/components/topology/state/form/Editor.tsx
@@ -1,14 +1,26 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import SaveSection from '@renderer/components/topology/state/form/SaveSection';
-import { useAppDispatch, useAppSelector } from '@renderer/app/store';
+import { useAppDispatch } from '@renderer/app/store';
 import { setSelectedObjectInfo } from '@renderer/features/codeSlice';
-import { selectCodeSelectedObjectInfo } from '@renderer/features/codeSliceInputSelectors';
 import DynamicForm from './index';
 import AddFieldSection from './AddFieldSection';
 
+let tempType: any;
+let tempResourceName: any;
+let tempInstanceName: any;
+let tempSourceSchema: any;
+
 const EditorTab = (props: EditorTabProps) => {
   const { schema, formData, uiSchema, id } = props;
+  const { type, resourceName, instanceName, sourceSchema } = props;
+
+  if (type && type !== '') {
+    tempType = type;
+    tempResourceName = resourceName;
+    tempInstanceName = instanceName;
+    tempSourceSchema = sourceSchema;
+  }
 
   const [formState, setFormState] = React.useState(formData);
   const [formSchema, setFormSchema] = React.useState(schema);
@@ -28,19 +40,16 @@ const EditorTab = (props: EditorTabProps) => {
     );
   }, [formState, formData, id]);
   const dispatch = useAppDispatch();
-  const { type, resourceName, instanceName, sourceSchema } = useAppSelector(
-    selectCodeSelectedObjectInfo
-  );
 
   const onChange = React.useCallback(({ formData }, e) => {
     setFormState(formData);
 
     const object = {
-      type,
-      resourceName,
-      instanceName,
+      type: tempType,
+      resourceName: tempResourceName,
+      instanceName: tempInstanceName,
       content: formData,
-      sourceSchema,
+      sourceSchema: tempSourceSchema,
     };
     dispatch(setSelectedObjectInfo(object));
   }, []);
@@ -77,6 +86,10 @@ type EditorTabProps = {
   formData: any;
   uiSchema: any;
   id: string;
+  type: any;
+  resourceName: any;
+  instanceName: any;
+  sourceSchema: any;
 };
 
 export default EditorTab;

--- a/src/renderer/components/topology/state/form/Editor.tsx
+++ b/src/renderer/components/topology/state/form/Editor.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import SaveSection from '@renderer/components/topology/state/form/SaveSection';
+import { useAppDispatch, useAppSelector } from '@renderer/app/store';
+import { setSelectedObjectInfo } from '@renderer/features/codeSlice';
+import { selectCodeSelectedObjectInfo } from '@renderer/features/codeSliceInputSelectors';
 import DynamicForm from './index';
 import AddFieldSection from './AddFieldSection';
 
@@ -24,9 +27,22 @@ const EditorTab = (props: EditorTabProps) => {
       )
     );
   }, [formState, formData, id]);
+  const dispatch = useAppDispatch();
+  const { type, resourceName, instanceName, sourceSchema } = useAppSelector(
+    selectCodeSelectedObjectInfo
+  );
 
   const onChange = React.useCallback(({ formData }, e) => {
     setFormState(formData);
+
+    const object = {
+      type,
+      resourceName,
+      instanceName,
+      content: formData,
+      sourceSchema,
+    };
+    dispatch(setSelectedObjectInfo(object));
   }, []);
   return (
     <>

--- a/src/renderer/components/topology/state/form/fields/MapField.tsx
+++ b/src/renderer/components/topology/state/form/fields/MapField.tsx
@@ -36,9 +36,17 @@ const MapField = (props: FieldProps) => {
 
   const [mapData, setMapData] = React.useState(formData);
 
-  React.useEffect(() => {
-    setMapData(formData);
-  }, [formData]);
+  //Editor.tsx 에서 onChange 에서 redux 값을 sidepanel과 동기화 했을때, configurable 속성이 false 로 변경된것을 찾을때 쓴 테스트 코드
+  //React.useEffect(() => {
+  //  console.log(Object.getOwnPropertyDescriptors(mapData));
+  //}, [mapData]);
+
+  //Editor.tsx 에서 onChange 에서 redux 값을 sidepanel과 동기화 했을때, configurable 속성이 false 로 변경되는것을 확인
+  //이부분 제거했을때, 정상동작으로 추정됨
+  //Editor.tsx 에서 onChange 에서 redux 값을 sidepanel과 동기화와 목적이 동일해 보여서 제거하고 테스트 함
+  //React.useEffect(() => {
+  //  setMapData(formData);
+  //}, [formData]);
 
   if (!additional) {
     return <>{children}</>;


### PR DESCRIPTION
[feat] 스키마 없을때 스키마 추가 비활성화
1. 스키마 리스트 길이가 0 이면 스키마 없음 이라는 문구로 변경
2. 스키마 리스트 길이가 0 이면 disable 시킴

[feat] 항목 추가 항상 열림 및 크기 조절
accodion 열려있게 하고 위치 조절함


[bugfix] 리소스 타입 에러 수정
프로바이더 오브젝트 추가할때 리소스 타입 provider 자리에 aws 등 프로바이더 이름으로 넣어주던 부분 수정


[bugfix] 키 삭제후 다른 키 추가 했을때 삭제 했던 키 다시 나타나는 현상 수정
key 삭제하면 formdata 만 업데이트 되고 redux selectedObjectInfo 는 업데이트가 없음
새로운 키 등록 하면 selectedObjectInfo 정보에 새로운 키를 등록한 상태로 다시 나옴
그래서 삭제한 키가 다시 나오게 됨
formData 변경될때마다 selectedObjectInfo 변경되도록 함


[bugfix] sidepanel 에서 변경시 schema 사라지는 버그 수정
type 등 빈 값이 들어오는 경우가 있어서 빈 값이면 저장했던 값 그대로 사용하도록함
새로 생성된 Object 의 configurable false 로 변경되어서 원인 분석 함

React.useEffect(() => {
  setMapData(formData);
}, [formData]);

과정에서 생기는 문제로 판단되어 주석처리함
위 동작은 formData 변경될때마다 selectedObjectInfo 변경되는 과정이 생겼으므로 필요 없어졌을 것으로 추측됨
